### PR TITLE
Update dev still failing sometimes

### DIFF
--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: commit
         run: |
+          git pull origin main
           git add pixi-versions.json
           git commit -m "new pixi-versions.json built from pixijs/pixijs: ${{ github.event.client_payload.ref }} merge commit: ${{ github.event.client_payload.pr_sha }} using CodeSandbox CI build: ${{ github.event.client_payload.sha }}"
           git push origin main

--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -30,3 +30,8 @@ jobs:
           git commit -m "new pixi-versions.json built from pixijs/pixijs: ${{ github.event.client_payload.ref }} merge commit: ${{ github.event.client_payload.pr_sha }} using CodeSandbox CI build: ${{ github.event.client_payload.sha }}"
           git push origin main
 
+  call-deploy:
+    uses: ./.github/workflows/reusable-deploy.yml
+    secrets: inherit
+
+

--- a/src/pages/versions.tsx
+++ b/src/pages/versions.tsx
@@ -94,7 +94,7 @@ export default function Version(): JSX.Element
                                     </Link>
                                 </td>
                                 <td>
-                                    <Link to={latestVersion.build}>
+                                    <Link to={devVersion.build}>
                                         <BuildLabel />
                                     </Link>
                                 </td>


### PR DESCRIPTION
`update-dev` fails sometimes because it complains `main` is not up to date: https://github.com/pixijs/beta.pixijs.com/actions/runs/4545230137/jobs/8052650073

Try pulling from `origin main` before committing