### PR TITLE
Added node to script so it runs correctly on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "types": "tsc --noEmit",
         "write-heading-ids": "docusaurus write-heading-ids",
         "write-translations": "docusaurus write-translations",
-        "write-example-docs": "./scripts/write-example-docs.js",
+        "write-example-docs": "node ./scripts/write-example-docs.js",
         "write-versions": "node ./scripts/write-versions.js",
         "prepare": "husky install"
     },


### PR DESCRIPTION
## The issue
In Windows, currently ```npm run start``` doesn't work. It produces the next error log:
```
PS D:\Documents\pixijs.com> npm run start                                                          

> pixi-docusaurus@0.0.0 prestart
> npm run write-example-docs


> pixi-docusaurus@0.0.0 write-example-docs
> ./scripts/write-example-docs.js

'.' is not recognized as an internal or external command,
operable program or batch file.
```

This refers to one of our package.json scripts. ```"write-example-docs": " ./scripts/write-example-docs.js",```

## The solution

This is fixed by adding "node" to our script so it writes ```"write-example-docs": "node ./scripts/write-example-docs.js",``` After this, now ```npm run start``` works correctly and the site loads correctly locally.

# This needs to be tested on linux/macos to make sure this addition doesn't break setups on other OS. 
