### PR TITLE
Replace interactive with eventMode on all examples

### DIFF
--- a/src/data/examples/advanced/collisionDetection.js
+++ b/src/data/examples/advanced/collisionDetection.js
@@ -97,7 +97,7 @@ redSquare.mass = 1;
 
 const mouseCoords = { x: 0, y: 0 };
 
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 app.stage.hitArea = app.screen;
 app.stage.on('mousemove', (event) =>
 {

--- a/src/data/examples/advanced/mouseTrail.js
+++ b/src/data/examples/advanced/mouseTrail.js
@@ -36,7 +36,7 @@ app.stage.addChild(rope);
 
 let mouseposition = null;
 
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 app.stage.hitArea = app.screen;
 app.stage.on('mousemove', (event) =>
 {

--- a/src/data/examples/advanced/scratchCard.js
+++ b/src/data/examples/advanced/scratchCard.js
@@ -34,7 +34,7 @@ function setup()
         renderTextureSprite,
     );
 
-    app.stage.interactive = true;
+    app.stage.eventMode = 'static';
     app.stage.hitArea = app.screen;
     app.stage
         .on('pointerdown', pointerDown)

--- a/src/data/examples/advanced/screenShot.js
+++ b/src/data/examples/advanced/screenShot.js
@@ -21,7 +21,7 @@ async function takeScreenshot()
     app.start();
 }
 
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 app.stage.hitArea = app.screen;
 app.stage.on('pointerdown', takeScreenshot);
 

--- a/src/data/examples/advanced/slots.js
+++ b/src/data/examples/advanced/slots.js
@@ -113,7 +113,7 @@ function onAssetsLoaded()
     app.stage.addChild(bottom);
 
     // Set the interactivity.
-    bottom.interactive = true;
+    bottom.eventMode = 'static';
     bottom.cursor = 'pointer';
     bottom.addListener('pointerdown', () =>
     {

--- a/src/data/examples/assets/background.js
+++ b/src/data/examples/assets/background.js
@@ -23,7 +23,7 @@ PIXI.Assets.load('eggHead').then((texture) =>
     character.anchor.set(0.5);
     character.x = app.screen.width / 2;
     character.y = app.screen.height / 2;
-    character.interactive = true;
+    character.eventMode = 'static';
     character.cursor = 'pointer';
 
     app.stage.addChild(character);

--- a/src/data/examples/assets/bundle.js
+++ b/src/data/examples/assets/bundle.js
@@ -50,7 +50,7 @@ async function makeLoadScreen()
     goNext.y = app.screen.height / 2;
     app.stage.addChild(goNext);
 
-    goNext.interactive = true;
+    goNext.eventMode = 'static';
     goNext.cursor = 'pointer';
 
     goNext.on('pointertap', async () =>
@@ -75,7 +75,7 @@ async function makeGameScreen()
     goBack.y = app.screen.height / 2;
     app.stage.addChild(goBack);
 
-    goBack.interactive = true;
+    goBack.eventMode = 'static';
     goBack.cursor = 'pointer';
 
     goBack.on('pointertap', async () =>

--- a/src/data/examples/basic/cacheAsBitmap.js
+++ b/src/data/examples/basic/cacheAsBitmap.js
@@ -28,7 +28,7 @@ alienContainer.x = 400;
 alienContainer.y = 300;
 
 // make the stage interactive
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 app.stage.addChild(alienContainer);
 
 function onAssetsLoaded()

--- a/src/data/examples/events/click.js
+++ b/src/data/examples/events/click.js
@@ -15,12 +15,12 @@ sprite.x = app.screen.width / 2;
 sprite.y = app.screen.height / 2;
 
 // Opt-in to interactivity
-sprite.interactive = true;
+sprite.eventMode = 'static';
 
 // Shows hand cursor
 sprite.cursor = 'pointer';
 
-// Pointers normalize touch and mouse
+// Pointers normalize touch and mouse (good for mobile and desktop)
 sprite.on('pointerdown', onClick);
 
 // Alternatively, use the mouse & touch events:

--- a/src/data/examples/events/customHitarea.js
+++ b/src/data/examples/events/customHitarea.js
@@ -11,7 +11,7 @@ const starButton1 = new PIXI.Sprite(yellowStar);
 
 starButton1.position.set(50, 200);
 starButton1.cursor = 'pointer';
-starButton1.interactive = true;
+starButton1.eventMode = 'static';
 
 starButton1
     .on('pointerdown', onClick, starButton1)
@@ -38,7 +38,7 @@ starButton2.hitArea = new PIXI.Polygon([
     60, 50,
 ]);
 starButton2.cursor = 'pointer';
-starButton2.interactive = true;
+starButton2.eventMode = 'static';
 
 starButton2
     .on('pointerdown', onClick, starButton2)
@@ -50,7 +50,7 @@ const starButton3 = new PIXI.Sprite(yellowStar);
 
 starButton3.position.set(450, 200);
 starButton3.cursor = 'pointer';
-starButton3.interactive = true;
+starButton3.eventMode = 'static';
 
 const squareMask = new PIXI.Graphics()
     .beginFill(0xFFFFFF)
@@ -92,7 +92,7 @@ starButton4.hitArea = new PIXI.Polygon([
     60, 50,
 ]);
 starButton4.cursor = 'pointer';
-starButton4.interactive = true;
+starButton4.eventMode = 'static';
 
 starButton4
     .on('pointerdown', onClick, starButton4)

--- a/src/data/examples/events/customMouseIcon.js
+++ b/src/data/examples/events/customMouseIcon.js
@@ -46,7 +46,7 @@ for (let i = 0; i < 5; i++)
     button.y = buttonPositions[i * 2 + 1];
 
     // make the button interactive...
-    button.interactive = true;
+    button.eventMode = 'static';
 
     button
         .on('pointerdown', onButtonDown)

--- a/src/data/examples/events/dragging.js
+++ b/src/data/examples/events/dragging.js
@@ -24,7 +24,7 @@ function createBunny(x, y)
     const bunny = new PIXI.Sprite(texture);
 
     // enable the bunny to be interactive... this will allow it to respond to mouse and touch events
-    bunny.interactive = true;
+    bunny.eventMode = 'static';
 
     // this button mode will mean the hand cursor appears when you roll over the bunny with your mouse
     bunny.cursor = 'pointer';
@@ -49,7 +49,7 @@ function createBunny(x, y)
 
 let dragTarget = null;
 
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 app.stage.hitArea = app.screen;
 app.stage.on('pointerup', onDragEnd);
 app.stage.on('pointerupoutside', onDragEnd);

--- a/src/data/examples/events/hitTestingWithSpatialHash.js
+++ b/src/data/examples/events/hitTestingWithSpatialHash.js
@@ -191,7 +191,7 @@ function main()
         sprite.scale.set(0.34);
 
         // Make the character interactive!
-        sprite.interactive = true;
+        sprite.eventMode = 'static';
 
         // Explode on clicks!
         sprite.addEventListener('click', onMonsterClicked);

--- a/src/data/examples/events/interactivity.js
+++ b/src/data/examples/events/interactivity.js
@@ -37,7 +37,7 @@ for (let i = 0; i < 5; i++)
     button.y = buttonPositions[i * 2 + 1];
 
     // make the button interactive...
-    button.interactive = true;
+    button.eventMode = 'static';
     button.cursor = 'pointer';
 
     button

--- a/src/data/examples/events/logger.js
+++ b/src/data/examples/events/logger.js
@@ -46,10 +46,10 @@ const whiteBox = blackBox.addChild(new PIXI.Graphics()
 whiteBox.name = 'white box';
 
 // Enable interactivity everywhere!
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 app.stage.hitArea = app.screen;
-whiteBox.interactive = true;
-blackBox.interactive = true;
+whiteBox.eventMode = 'static';
+blackBox.eventMode = 'static';
 
 function onEvent(e)
 {

--- a/src/data/examples/events/nestedBoundaryWithProjection.js
+++ b/src/data/examples/events/nestedBoundaryWithProjection.js
@@ -62,7 +62,7 @@ class Projector extends PIXI.DisplayObject
             this.addEventListener(event, (e) => this.boundary.mapEvent(e));
         });
 
-        this.interactive = true;
+        this.eventMode = 'static';
     }
 
     // Pass through cursor
@@ -163,13 +163,13 @@ projector.content.hitArea = new PIXI.Rectangle(-100, -300, app.screen.width, app
 // Make hit-area cover the whole screen so we can capture
 // pointermove everywhere!
 projector.hitArea = projector.content.hitArea;
-projector.content.interactive = true;
+projector.content.eventMode = 'static';
 
 // Make stars interactive & add wheel handlers
 stars.forEach((star) =>
 {
     // Make star interactive
-    star.interactive = true;
+    star.eventMode = 'static';
 
     // Set initial cursor
     star.cursor = 'zoom-in';

--- a/src/data/examples/events/pointerTracker.js
+++ b/src/data/examples/events/pointerTracker.js
@@ -20,7 +20,7 @@ const circle = app.stage.addChild(new PIXI.Graphics()
 circle.position.set(app.screen.width / 2, app.screen.height / 2);
 
 // Enable interactivity!
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 
 // Make sure the whole canvas area is interactive, not just the circle.
 app.stage.hitArea = app.screen;

--- a/src/data/examples/events/slider.js
+++ b/src/data/examples/events/slider.js
@@ -29,7 +29,7 @@ const handle = new PIXI.Graphics()
 
 handle.y = slider.height / 2;
 handle.x = sliderWidth / 2;
-handle.interactive = true;
+handle.eventMode = 'static';
 handle.cursor = 'pointer';
 
 handle
@@ -66,14 +66,14 @@ app.stage.addChild(title);
 // Listen to pointermove on stage once handle is pressed.
 function onDragStart()
 {
-    app.stage.interactive = true;
+    app.stage.eventMode = 'static';
     app.stage.addEventListener('pointermove', onDrag);
 }
 
 // Stop dragging feedback once the handle is released.
 function onDragEnd(e)
 {
-    app.stage.interactive = false;
+    app.stage.eventMode = 'auto';
     app.stage.removeEventListener('pointermove', onDrag);
 }
 

--- a/src/data/examples/filtersAdvanced/mouseBlending.js
+++ b/src/data/examples/filtersAdvanced/mouseBlending.js
@@ -51,7 +51,7 @@ const filter = new PIXI.Filter(null, shaderFrag, {
 container.filters = [filter];
 
 app.stage.hitArea = app.screen;
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 app.stage.on('pointermove', (event) =>
 {
     filter.uniforms.mouse.copyFrom(event.global);

--- a/src/data/examples/filtersBasic/colorMatrix.js
+++ b/src/data/examples/filtersBasic/colorMatrix.js
@@ -4,7 +4,7 @@ const app = new PIXI.Application({ resizeTo: window });
 
 document.body.appendChild(app.view);
 
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 
 const bg = PIXI.Sprite.from('https://pixijs.com/assets/bg_rotate.jpg');
 

--- a/src/data/examples/filtersBasic/displacementMapCrawlies.js
+++ b/src/data/examples/filtersBasic/displacementMapCrawlies.js
@@ -4,7 +4,7 @@ const app = new PIXI.Application({ resizeTo: window });
 
 document.body.appendChild(app.view);
 
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 
 const container = new PIXI.Container();
 

--- a/src/data/examples/filtersBasic/displacementMapFlag.js
+++ b/src/data/examples/filtersBasic/displacementMapFlag.js
@@ -4,7 +4,7 @@ const app = new PIXI.Application({ resizeTo: window });
 
 document.body.appendChild(app.view);
 
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 
 const container = new PIXI.Container();
 

--- a/src/data/examples/graphics/dynamic.js
+++ b/src/data/examples/graphics/dynamic.js
@@ -4,7 +4,7 @@ const app = new PIXI.Application({ antialias: true, resizeTo: window });
 
 document.body.appendChild(app.view);
 
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 app.stage.hitArea = app.screen;
 
 const graphics = new PIXI.Graphics();

--- a/src/data/examples/masks/filter.js
+++ b/src/data/examples/masks/filter.js
@@ -32,7 +32,7 @@ PIXI.Assets.load('https://pixijs.com/assets/bg_grass.jpg').then((grassTexture) =
     app.stage.addChild(focus);
     background.mask = focus;
 
-    app.stage.interactive = true;
+    app.stage.eventMode = 'static';
     app.stage.hitArea = app.screen;
     app.stage.on('pointermove', (event) =>
     {

--- a/src/data/examples/masks/graphics.js
+++ b/src/data/examples/masks/graphics.js
@@ -4,7 +4,7 @@ const app = new PIXI.Application({ antialias: true, resizeTo: window });
 
 document.body.appendChild(app.view);
 
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 
 const bg = PIXI.Sprite.from('https://pixijs.com/assets/bg_rotate.jpg');
 

--- a/src/data/examples/masks/sprite.js
+++ b/src/data/examples/masks/sprite.js
@@ -4,7 +4,7 @@ const app = new PIXI.Application({ resizeTo: window });
 
 document.body.appendChild(app.view);
 
-app.stage.interactive = true;
+app.stage.eventMode = 'static';
 
 const bg = PIXI.Sprite.from('https://pixijs.com/assets/bg_plane.jpg');
 

--- a/src/data/examples/sprite/textureSwap.js
+++ b/src/data/examples/sprite/textureSwap.js
@@ -22,7 +22,7 @@ character.y = app.screen.height / 2;
 app.stage.addChild(character);
 
 // make the sprite interactive
-character.interactive = true;
+character.eventMode = 'static';
 character.cursor = 'pointer';
 
 character.on('pointertap', () =>

--- a/src/data/examples/sprite/video.js
+++ b/src/data/examples/sprite/video.js
@@ -19,7 +19,7 @@ button.x = (app.screen.width - button.width) / 2;
 button.y = (app.screen.height - button.height) / 2;
 
 // Enable interactivity on the button
-button.interactive = true;
+button.eventMode = 'static';
 button.cursor = 'pointer';
 
 // Add to the stage


### PR DESCRIPTION
Since pixi 7.20, we are using eventMode instead of interactive to make our displayObjects be interactive/have events. Therefore, our examples should also show eventMode and don't confuse new developers/make sure they make interactive objects the right way.

This PR only changes the next:
```
from

interactive = true/false;

to

eventMode = 'static'/'auto';
```

I manually tested each example changed and made sure they worked with the new change OR that the example is not working currently by checking on https://pixijs.com/examples (will be making issues for those that don't work so we know and fix them).

