### PR TITLE
fix broken links to tags

### DIFF
--- a/pixi-versions.json
+++ b/pixi-versions.json
@@ -11,7 +11,7 @@
   {
     "versionLabel": "v7.2.x",
     "version": "7.2.4",
-    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tags/v7.2.4",
+    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tag/v7.2.4",
     "build": "https://pixijs.download/v7.2.4/pixi.min.js",
     "docs": "https://pixijs.download/v7.2.4/docs/index.html",
     "npm": "7.2.4",
@@ -20,7 +20,7 @@
   {
     "versionLabel": "v7.1.x",
     "version": "7.1.4",
-    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tags/v7.1.4",
+    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tag/v7.1.4",
     "build": "https://pixijs.download/v7.1.4/pixi.min.js",
     "docs": "https://pixijs.download/v7.1.4/docs/index.html",
     "npm": "7.1.4"
@@ -28,7 +28,7 @@
   {
     "versionLabel": "v7.0.x",
     "version": "7.0.5",
-    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tags/v7.0.5",
+    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tag/v7.0.5",
     "build": "https://pixijs.download/v7.0.5/pixi.min.js",
     "docs": "https://pixijs.download/v7.0.5/docs/index.html",
     "npm": "7.0.5"
@@ -36,7 +36,7 @@
   {
     "versionLabel": "v6.x",
     "version": "6.5.10",
-    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tags/v6.5.10",
+    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tag/v6.5.10",
     "build": "https://pixijs.download/v6.5.10/pixi.min.js",
     "docs": "https://pixijs.download/v6.5.10/docs/index.html",
     "npm": "6.5.10"
@@ -44,7 +44,7 @@
   {
     "versionLabel": "v5.x",
     "version": "5.3.12",
-    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tags/v5.3.12",
+    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tag/v5.3.12",
     "build": "https://pixijs.download/v5.3.12/pixi.min.js",
     "docs": "https://pixijs.download/v5.3.12/docs/index.html",
     "npm": "5.3.12"
@@ -52,7 +52,7 @@
   {
     "versionLabel": "v4.x",
     "version": "4.8.9",
-    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tags/v4.8.9",
+    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tag/v4.8.9",
     "build": "https://pixijs.download/v4.8.9/pixi.min.js",
     "docs": "https://pixijs.download/v4.8.9/docs/index.html",
     "npm": "4.8.9"

--- a/scripts/write-versions.js
+++ b/scripts/write-versions.js
@@ -54,7 +54,7 @@ const { compareVersions } = require('compare-versions');
         {
             versionLabel: 'v4.x',
             version: v4,
-            releaseNotes: `https://github.com/pixijs/pixijs/releases/tags/v${v4}`,
+            releaseNotes: `https://github.com/pixijs/pixijs/releases/tag/v${v4}`,
             build: `https://pixijs.download/v${v4}/pixi.min.js`,
             docs: `https://pixijs.download/v${v4}/docs/index.html`,
             npm: v4,
@@ -62,7 +62,7 @@ const { compareVersions } = require('compare-versions');
         {
             versionLabel: 'v5.x',
             version: v5,
-            releaseNotes: `https://github.com/pixijs/pixijs/releases/tags/v${v5}`,
+            releaseNotes: `https://github.com/pixijs/pixijs/releases/tag/v${v5}`,
             build: `https://pixijs.download/v${v5}/pixi.min.js`,
             docs: `https://pixijs.download/v${v5}/docs/index.html`,
             npm: v5,
@@ -70,7 +70,7 @@ const { compareVersions } = require('compare-versions');
         {
             versionLabel: 'v6.x',
             version: v6,
-            releaseNotes: `https://github.com/pixijs/pixijs/releases/tags/v${v6}`,
+            releaseNotes: `https://github.com/pixijs/pixijs/releases/tag/v${v6}`,
             build: `https://pixijs.download/v${v6}/pixi.min.js`,
             docs: `https://pixijs.download/v${v6}/docs/index.html`,
             npm: v6,
@@ -84,7 +84,7 @@ const { compareVersions } = require('compare-versions');
         versions.push({
             versionLabel: `v${v.split('.').slice(0, 2).join('.')}.x`,
             version: v,
-            releaseNotes: `https://github.com/pixijs/pixijs/releases/tags/v${v}`,
+            releaseNotes: `https://github.com/pixijs/pixijs/releases/tag/v${v}`,
             build: `https://pixijs.download/v${v}/pixi.min.js`,
             docs: `https://pixijs.download/v${v}/docs/index.html`,
             npm: v,
@@ -96,7 +96,7 @@ const { compareVersions } = require('compare-versions');
         versions.push({
             versionLabel: `v${prerelease}`,
             version: prerelease,
-            releaseNotes: `https://github.com/pixijs/pixijs/releases/tags/v${prerelease}`,
+            releaseNotes: `https://github.com/pixijs/pixijs/releases/tag/v${prerelease}`,
             build: `https://pixijs.download/v${prerelease}/pixi.min.js`,
             docs: `https://pixijs.download/v${prerelease}/docs/index.html`,
             npm: prerelease,


### PR DESCRIPTION
Check the "Release Notes" on the https://pixijs.com/versions page. Currently they link to a 404 page because the URL incorrectly links to https://github.com/pixijs/pixijs/releases/tags/vx.x.x (notice the "s" in tags) instead of https://github.com/pixijs/pixijs/releases/tag/vx.x.x