### PR TITLE
Fix: Link to the dev documentation

### DIFF
--- a/pixi-versions.json
+++ b/pixi-versions.json
@@ -4,7 +4,7 @@
     "version": "dev",
     "releaseNotes": "https://github.com/pixijs/pixijs/releases",
     "build": "https://pixijs.download/dev/pixi.min.js",
-    "docs": "https://pixijs.download/release/docs",
+    "docs": "https://pixijs.download/dev/docs/index.html",
     "dev": true,
     "npm": "https://pkg.csb.dev/pixijs/pixijs/commit/84fa8bcc"
   },


### PR DESCRIPTION
The link to the documentation for dev in <https://pixijs.com/versions#latest> is <https://pixijs.download/release/docs>, which turns out to be an AccessDenied. This PR fixes this issue.

Fixes pixijs/pixijs#10038.