### PR TITLE
Fix: Link to API document

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -10,5 +10,5 @@ If you're new to PixiJS, we suggest you start with the Basics and read through t
 
 As you explore the guides, you may find these resources valuable:
 
-* [PixiJS API documentation](https://pixijs.download/release/docs)
+* [PixiJS API documentation](https://pixijs.download/release/docs/index.html)
 * [PixiJS Github repo](https://github.com/pixijs/pixijs)

--- a/scripts/write-versions.js
+++ b/scripts/write-versions.js
@@ -109,7 +109,7 @@ const { compareVersions } = require('compare-versions');
         version: 'dev',
         releaseNotes: 'https://github.com/pixijs/pixijs/releases',
         build: 'https://pixijs.download/dev/pixi.min.js',
-        docs: 'https://pixijs.download/release/docs',
+        docs: 'https://pixijs.download/release/docs/index.html',
         dev: true,
         npm: codeSandboxBaseUrl,
     });


### PR DESCRIPTION
Fix the link to the API document in <https://pixijs.com/guides>.

Fixes pixijs/pixijs#10115.