### PR TITLE
Fix: NavBar not highlighting selected version

### DIFF
--- a/blog/2024-03-05-pixi-v8-launches.md
+++ b/blog/2024-03-05-pixi-v8-launches.md
@@ -39,8 +39,8 @@ We're incredibly proud of PixiJS v8 and eager to share the improvements and new 
 
 ## 🔗 Quick links
 - The new Docs for v8 can be found [here](https://pixijs.download/v8.0.0/docs/index.html)
-- [Migration](/guides/migrations/v8)
-- [Examples](/examples)
+- [Migration](8.x/guides/migrations/v8)
+- [Examples](8.x/examples)
 - [Open Games](https://github.com/pixijs/open-games)
 
 ---
@@ -197,7 +197,7 @@ myContainer.blendMode = 'color-burn` // easy!
 
 ```
 
-For more information on these graphics upgrades and guidance on how to adapt to the enhanced Graphics API, please refer to the [migration guide](/guides/migrations/v8), or why not jump in and play with some [examples](examples/graphics/simple).
+For more information on these graphics upgrades and guidance on how to adapt to the enhanced Graphics API, please refer to the [migration guide](8.x/guides/migrations/v8), or why not jump in and play with some [examples](8.x/examples/graphics/simple).
 
 #### 📝 Text Upgrades
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,8 +51,8 @@ const config = {
                         },
 
                         current: {
-                            label: 'v8.x (Latest)',
-                            path: '',
+                            label: 'v8.x',
+                            path: '8.x',
                             banner: 'none',
                             badge: false,
                         },

--- a/scripts/update-global-version-configs.js
+++ b/scripts/update-global-version-configs.js
@@ -79,7 +79,7 @@ recast.visit(ast, {
                             recast.types.builders.property(
                                 'init',
                                 recast.types.builders.identifier('path'),
-                                recast.types.builders.literal(version.isCurrent ? '' : key),
+                                recast.types.builders.literal(key),
                             ),
                             recast.types.builders.property(
                                 'init',

--- a/src/components/Homepage/ClosingSection/index.tsx
+++ b/src/components/Homepage/ClosingSection/index.tsx
@@ -37,7 +37,7 @@ export default function ClosingSection(): JSX.Element
                                 anim="short-up-anim"
                                 style={animShortUp(0.3, 0.7)}
                                 label="Get Started"
-                                link="/tutorials"
+                                link="8.x/tutorials"
                                 outline={true}
                             />
                         </div>

--- a/src/components/Homepage/HeroHeader/index.tsx
+++ b/src/components/Homepage/HeroHeader/index.tsx
@@ -16,7 +16,7 @@ export default function HeroHeader(): JSX.Element
                 <div className="buttonRow">
                     <HomeCTA label="Download" link="https://github.com/pixijs/pixijs/releases" />
                     &nbsp;
-                    <HomeCTA label="Get Started" link="/tutorials" white={true} outline={true} />
+                    <HomeCTA label="Get Started" link="8.x/tutorials" white={true} outline={true} />
                 </div>
             </div>
         </header>


### PR DESCRIPTION
- Latest version now uses the version key for pathing rather than nothing on the URL, which broke the versioning functionality on the nav bar before.
- This also fixes the broken search functionality.