### PR TITLE
Fix: Correctly Updates Generic Version Configs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,12 +48,14 @@ const config = {
                             label: 'v7.x',
                             path: '7.x',
                             banner: 'none',
+                            badge: true,
                         },
 
                         current: {
                             label: 'v8.x',
                             path: '8.x',
                             banner: 'none',
+                            badge: true,
                         },
                     },
                 },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,14 +48,12 @@ const config = {
                             label: 'v7.x',
                             path: '7.x',
                             banner: 'none',
-                            badge: true,
                         },
 
                         current: {
                             label: 'v8.x',
                             path: '8.x',
                             banner: 'none',
-                            badge: true,
                         },
                     },
                 },

--- a/scripts/update-global-version-configs.js
+++ b/scripts/update-global-version-configs.js
@@ -86,6 +86,11 @@ recast.visit(ast, {
                                 recast.types.builders.identifier('banner'),
                                 recast.types.builders.literal('none'),
                             ),
+                            recast.types.builders.property(
+                                'init',
+                                recast.types.builders.identifier('badge'),
+                                recast.types.builders.literal(true),
+                            ),
                         );
 
                         return recast.types.builders.property(

--- a/scripts/update-global-version-configs.js
+++ b/scripts/update-global-version-configs.js
@@ -86,11 +86,6 @@ recast.visit(ast, {
                                 recast.types.builders.identifier('banner'),
                                 recast.types.builders.literal('none'),
                             ),
-                            recast.types.builders.property(
-                                'init',
-                                recast.types.builders.identifier('badge'),
-                                recast.types.builders.literal(false),
-                            ),
                         );
 
                         return recast.types.builders.property(

--- a/scripts/update-pixi-version-configs.js
+++ b/scripts/update-pixi-version-configs.js
@@ -1,3 +1,4 @@
+/* eslint-disable radix */
 const { resolve } = require('path');
 const { readFileSync, existsSync } = require('fs');
 const shell = require('shelljs');


### PR DESCRIPTION
- Fix the script altering generic versions' label (eg. 'v7.x', 'v8.x') back to specific ones.
- Should now also bump up the generic version configs to their latest available version within their major.
- Change re-writing to `badge: true` on the Docusaurus config.