### PR TITLE
fix v8.0 bitmaptext example

### DIFF
--- a/src/examples/v8.0.0/text/bitmapText.js
+++ b/src/examples/v8.0.0/text/bitmapText.js
@@ -1,4 +1,4 @@
-import { Application, Assets, Text } from 'pixi.js';
+import { Application, Assets, BitmapText } from 'pixi.js';
 
 (async () =>
 {
@@ -14,14 +14,13 @@ import { Application, Assets, Text } from 'pixi.js';
     // Load bitmap font
     await Assets.load('https://pixijs.com/assets/bitmap-font/desyrel.xml');
 
-    const bitmapFontText = new Text({
+    const bitmapFontText = new BitmapText({
         text: 'bitmap fonts are supported!\nWoo yay!',
         style: {
             fontFamily: 'Desyrel',
             fontSize: 55,
             align: 'left',
         },
-        renderMode: 'bitmap',
     });
 
     bitmapFontText.x = 50;


### PR DESCRIPTION
- fix script to use `BitmapText` class
- without renderMode option

![image](https://github.com/pixijs/pixijs.com/assets/24370799/1c0e6e26-a929-4c84-9877-dc66f701a37f)
