### PR TITLE
fix link to v8 migration guide

### DIFF
--- a/blog/2024-03-05-pixi-v8-launches.md
+++ b/blog/2024-03-05-pixi-v8-launches.md
@@ -197,7 +197,7 @@ myContainer.blendMode = 'color-burn` // easy!
 
 ```
 
-For more information on these graphics upgrades and guidance on how to adapt to the enhanced Graphics API, please refer to the [migration guide](8.x/guides/migrations/v8), or why not jump in and play with some [examples](8.x/examples/graphics/simple).
+For more information on these graphics upgrades and guidance on how to adapt to the enhanced Graphics API, please refer to the [migration guide](/8.x/guides/migrations/v8), or why not jump in and play with some [examples](8.x/examples/graphics/simple).
 
 #### 📝 Text Upgrades
 


### PR DESCRIPTION
- from domain root

`8.x/guides/migrations/v8` =>  `/8.x/guides/migrations/v8`