### PR TITLE
Fix [code block]: scene-graph.md Render Order example

### DIFF
--- a/docs/guides/basics/scene-graph.md
+++ b/docs/guides/basics/scene-graph.md
@@ -126,8 +126,8 @@ let d = addLetter('D', app.stage, 0xff8800, {x: 140, y: 100});
 
 // Display them over time, in order
 let elapsed = 0.0;
-app.ticker.add((delta) => {
-  elapsed += delta / 60.0;
+app.ticker.add((ticker) => {
+  elapsed += ticker.deltaTime / 60.0;
   if (elapsed >= letters.length) { elapsed = 0.0; }
   for (let i = 0; i < letters.length; i ++) {
     letters[i].visible = elapsed >= i;


### PR DESCRIPTION
Missing curly brackets to destructure from the Ticker parameter. Alternatively and for the sake of instruction consider not destructuring the property from the param. I provided the latter option in the change. The example will not run without this fix.