### PR TITLE
Fix typo in components/interaction.md guide

### DIFF
--- a/docs/guides/components/interaction.md
+++ b/docs/guides/components/interaction.md
@@ -10,7 +10,7 @@ The new event-based system that replaced `InteractionManager` from v6 has expand
 |---|---|
 | `none` | Ignores all interaction events, similar to CSS's `pointer-events: none`, good optimization for non-interactive children |
 |  `passive`  | Does not emit events and ignores hit testing on itself but does allow for events and hit testing only its interactive children. This is default eventMode for all containers |
-|  `auto`  | Does not emit events and but is hit tested if parent is interactive. Same as `interactive = false` in v7 |
+|  `auto`  | Does not emit events but is hit tested if parent is interactive. Same as `interactive = false` in v7 |
 |  `static`  | Emit events and is hit tested. Same as `interaction = true` in v7, useful for objects like buttons that do not move. |
 |  `dynamic` | Emits events and is hit tested but will also receive mock interaction events fired from a ticker to allow for interaction when the mouse isn't moving. This is useful for elements that are independently moving or animating. |
 


### PR DESCRIPTION
Fix typo in docs 

I've looked into repo history a bit, but didn't find anything suggesting that some part of that sentence was between "and" and "but" before. 
