### PR TITLE
Update links to graphics masks example

### DIFF
--- a/docs/guides/components/graphics.md
+++ b/docs/guides/components/graphics.md
@@ -144,7 +144,7 @@ Doing so is simple.  Create the object, call the various builder functions to ad
 
 You can also use a Graphics object as a complex mask.  To do so, build your object and primitives as usual.  Next create a `Container` object that will contain the masked content, and set its `mask` property to your Graphics object.  The children of the container will now be clipped to only show through inside the geometry you've created.  This technique works for both WebGL and Canvas-based rendering.
 
-Check out the [masking example code](../../examples/graphics/simple).
+Check out the [masking example code](../../examples/masks/graphics).
 
 ## Caveats and Gotchas
 

--- a/versioned_docs/version-7.x/guides/components/graphics.md
+++ b/versioned_docs/version-7.x/guides/components/graphics.md
@@ -83,7 +83,7 @@ Doing so is simple.  Create the object, call the various builder functions to ad
 
 You can also use a Graphics object as a complex mask.  To do so, build your object and primitives as usual.  Next create a PIXI.Container object that will contain the masked content, and set its `mask` property to your Graphics object.  The children of the container will now be clipped to only show through inside the geometry you've created.  This technique works for both WebGL and Canvas-based rendering.
 
-Check out the [masking example code](../../examples/graphics/simple).
+Check out the [masking example code](../../examples/masks/graphics).
 
 ## Caveats and Gotchas
 


### PR DESCRIPTION
The current documentation in both versions contains a link to a `Graphics` example without a mask, even though the link title implies it should be an example with a mask. I have replaced the link with a more relevant example.