### PR TITLE
Fix: guides components containers masking code sample

### DIFF
--- a/docs/guides/components/containers.md
+++ b/docs/guides/components/containers.md
@@ -72,7 +72,9 @@ maskContainer.position.set(4,4);
 frame.addChild(maskContainer);
 
 // Create contents for the masked container
-let text = new Text({
+//
+// First, create a text texture
+let textTexture = app.renderer.canvasText.getTexture({
   text:'This text will scroll up and be masked, so you can see how masking works.  Lorem ipsum and all that.\n\n' +
   'You can put anything in the container and it will be masked!',
   style:{
@@ -83,6 +85,9 @@ let text = new Text({
   },
   x:10
 });
+
+// Then, create a Sprite from the text texture
+const text = new Sprite(textTexture);
 
 maskContainer.addChild(text);
 

--- a/docs/guides/components/containers.md
+++ b/docs/guides/components/containers.md
@@ -37,6 +37,10 @@ Think of a pop-up window.  It has a frame made of one or more Sprites, then has 
 ```ts
 // Create the application helper and add its render target to the page
 let app = new Application({ width: 640, height: 360 });
+
+// Initialize the application
+await app.init({ resizeTo: window });
+
 document.body.appendChild(app.view);
 
 // Create window frame


### PR DESCRIPTION
Update the `guides/components/containers#masking` sample code to work with the new `View`-implementing implementation of `Text`.

Refs:
- https://github.com/pixijs/pixijs/issues/10420#issuecomment-2045978825
- https://github.com/pixijs/pixijs/pull/10431