### PR TITLE
docs: fix typo and add semicolons for tutorial

### DIFF
--- a/src/tutorials/v8.0.0/gettingStarted/step1-content.md
+++ b/src/tutorials/v8.0.0/gettingStarted/step1-content.md
@@ -8,7 +8,7 @@ We will be using an asynchronous immediately invoked function expression ([IIFE]
 
 ## Application Setup
 
-Let's create the application and initialize it within the the IIFE before appending the its canvas to the DOM. If you came from PixiJS v7 or below, the key differences to pay attention to is that application options are now passed in as an object parameter to the `init` call, and that it is asynchronous which should be awaited before proceeding to use the application.
+Let's create the application and initialize it within the IIFE before appending its canvas to the DOM. If you came from PixiJS v7 or below, the key differences to pay attention to is that application options are now passed in as an object parameter to the `init` call, and that it is asynchronous which should be awaited before proceeding to use the application.
 
 ```javascript
 const app = new Application();

--- a/src/tutorials/v8.0.0/gettingStarted/step2-content.md
+++ b/src/tutorials/v8.0.0/gettingStarted/step2-content.md
@@ -21,8 +21,8 @@ app.stage.addChild(bunny);
 Now let's set the Sprite's anchor and position it so that it's bang on at the center.
 
 ```javascript
-bunny.anchor.set(0.5)
+bunny.anchor.set(0.5);
 
-bunny.x = app.screen.width / 2
-bunny.y = app.screen.height / 2
+bunny.x = app.screen.width / 2;
+bunny.y = app.screen.height / 2;
 ```


### PR DESCRIPTION
- Remove duplicate `the`
- Add semicolons for consistency