### PR TITLE
fix: a variety of links, docs, and tutorial issues

### DIFF
--- a/docs/guides/components/interaction.md
+++ b/docs/guides/components/interaction.md
@@ -33,7 +33,7 @@ PixiJS supports the following event types:
 | `globalpointermove` | Fired when a pointer device is moved, regardless of hit-testing the current object.                                |
 | `pointerout`        | Fired when a pointer device is moved off the display object.                                                       |
 | `pointerover`       | Fired when a pointer device is moved onto the display object.                                                      |
-| `pointertap`        | Fired when a pointer device is tapped twice on the display object.                                                 |
+| `pointertap`        | Fired when a pointer device is tapped on the display object.                                                       |
 | `pointerup`         | Fired when a pointer device button is released over the display object.                                            |
 | `pointerupoutside`  | Fired when a pointer device button is released outside the display object that initially registered a pointerdown. |
 | `mousedown `        | Fired when a mouse button is pressed on the display object.                                                        |
@@ -52,7 +52,7 @@ PixiJS supports the following event types:
 | `touchmove `        | Fired when a touch point is moved along the display object.                                                        |
 | `globaltouchmove`   | Fired when a touch point is moved, regardless of hit-testing the current object.                                   |
 | `touchstart `       | Fired when a touch point is placed on the display object.                                                          |
-| `tap `              | Fired when a touch point is tapped twice on the display object.                                                    |
+| `tap `              | Fired when a touch point is tapped on the display object.                                                          |
 | `wheel `            | Fired when a mouse wheel is spun over the display object.                                                          |
 | `rightclick `       | Fired when a right mouse button is clicked (pressed and released) over the display object.                         |
 | `rightdown `        | Fired when a right mouse button is pressed on the display object.                                                  |

--- a/docs/guides/migrations/v5.md
+++ b/docs/guides/migrations/v5.md
@@ -37,7 +37,7 @@ PIXI.settings.PREFER_ENV = PIXI.ENV.WEBGL;
 
 PixiJS v5 introduces a new class called `PIXI.Mesh`. This allows overriding the default shader and the ability to add more attributes to geometry. For [example](https://pixijs.io/examples/#/mesh/triangle-textured.js), you can add colors to vertices.
 
-The old v4 Mesh class has moved from `PIXI.mesh.Mesh` to [`PIXI.SimpleMesh`](http://pixijs.download/dev/docs/PIXI.SimpleMesh.html), it extends `PIXI.Mesh`.
+The old v4 Mesh class has moved from `PIXI.mesh.Mesh` to [`PIXI.SimpleMesh`](http://pixijs.download/v5.3.12/docs/PIXI.SimpleMesh.html), it extends `PIXI.Mesh`.
 
 `PIXI.mesh.Rope`, `PIXI.mesh.Plane`, `PIXI.mesh.NineSlicePlane` have moved to `PIXI.SimpleRope`, `PIXI.SimplePlane` and `PIXI.NineSlicePlane` respectively.
 
@@ -123,7 +123,7 @@ In v5, this code is no longer needed.
 
 One of the newest features in v5 is that we decoupled all the asset-specific functionality from BaseTexture. We created a new system called "resources" and each BaseTexture now has a resource that wraps some specific asset type. For instance: VideoResource, SVGResource, ImageResource, CanvasResource. In the future, we hope to be able to add other resource types. If there were asset-specific methods or properties being called before, these will probably be on `baseTexture.resource`.
 
-Also, we removed all of the `from*` methods from BaseTexture, so you just can call `BaseTexture.from` and pass in whatever resource. Please see [docs](http://pixijs.download/dev/docs/PIXI.BaseTexture.html) for more information about `from`.
+Also, we removed all of the `from*` methods from BaseTexture, so you just can call `BaseTexture.from` and pass in whatever resource. Please see [docs](http://pixijs.download/v5.3.12/docs/PIXI.BaseTexture.html) for more information about `from`.
 
 ```js
 const canvas = document.createElement('canvas');

--- a/docs/pixi-version.json
+++ b/docs/pixi-version.json
@@ -1,10 +1,10 @@
 {
   "versionLabel": "v8.x",
-  "version": "8.5.1",
-  "releaseNotes": "https://github.com/pixijs/pixijs/releases/tag/v8.5.1",
-  "build": "https://pixijs.download/v8.5.1/pixi.min.js",
-  "docs": "https://pixijs.download/v8.5.1/docs/index.html",
-  "npm": "8.5.1",
+  "version": "8.6.0",
+  "releaseNotes": "https://github.com/pixijs/pixijs/releases/tag/v8.6.0",
+  "build": "https://pixijs.download/v8.6.0/pixi.min.js",
+  "docs": "https://pixijs.download/v8.6.0/docs/index.html",
+  "npm": "8.6.0",
   "prerelease": false,
   "latest": true
 }

--- a/pixi-versions.json
+++ b/pixi-versions.json
@@ -12,11 +12,11 @@
   },
   {
     "versionLabel": "v8.x",
-    "version": "8.5.1",
-    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tag/v8.5.1",
-    "build": "https://pixijs.download/v8.5.1/pixi.min.js",
-    "docs": "https://pixijs.download/v8.5.1/docs/index.html",
-    "npm": "8.5.1",
+    "version": "8.6.0",
+    "releaseNotes": "https://github.com/pixijs/pixijs/releases/tag/v8.6.0",
+    "build": "https://pixijs.download/v8.6.0/pixi.min.js",
+    "docs": "https://pixijs.download/v8.6.0/docs/index.html",
+    "npm": "8.6.0",
     "prerelease": false,
     "latest": true,
     "isCurrent": true

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -15,7 +15,10 @@ export default function Team(): JSX.Element
     });
 
     return (
-        <Layout title={'Meet the Team'} description="Description will go into a meta tag in <head />">
+        <Layout
+            title={'Meet the Team'}
+            description="The handful of dedicated individuals who volunteer their time to make PixiJS better."
+        >
             <main>
                 <div className={`${styles.header} padding-horiz--lg text--center margin-vert--xl`}>
                     <h1 className="underline">Meet the Team</h1>

--- a/src/tutorials/v7.0.0/gettingStarted/step2-content.md
+++ b/src/tutorials/v7.0.0/gettingStarted/step2-content.md
@@ -2,7 +2,7 @@
 
 So far all we've been doing is prep work. We haven't actually told PixiJS to draw anything. Let's fix that by adding an image to be displayed.
 
-There are a number of ways to draw images in PixiJS, but the simplest is by using a [Sprite](https://pixijs.download/release/docs/PIXI.Sprite.html). We'll get into the details of how the scene graph works in a later guide, but for now all you need to know is that PixiJS renders a hierarchy of [DisplayObjects](https://pixijs.download/release/docs/PIXI.DisplayObject.html). A Sprite is a type of DisplayObject that wraps a loaded image resource to allow drawing it, scaling it, rotating it, and so forth.
+There are a number of ways to draw images in PixiJS, but the simplest is by using a [Sprite](https://pixijs.download/v7.4.2/docs/PIXI.Sprite.html). We'll get into the details of how the scene graph works in a later guide, but for now all you need to know is that PixiJS renders a hierarchy of [DisplayObjects](https://pixijs.download/v7.4.2/docs/PIXI.DisplayObject.html). A Sprite is a type of DisplayObject that wraps a loaded image resource to allow drawing it, scaling it, rotating it, and so forth.
 
 Before PixiJS can render an image, it needs to be loaded. Just like in any web page, image loading happens asynchronously. We'll talk a lot more about resource loading in later guides. For now, we can use a helper method on the PIXI.Sprite class to handle the image loading for us:
 
@@ -11,7 +11,7 @@ Before PixiJS can render an image, it needs to be loaded. Just like in any web p
 const bunny = PIXI.Sprite.from('https://pixijs.com/assets/bunny.png')
 ```
 
-Then we need to add our new sprite to the stage. The stage is simply a [Container](https://pixijs.download/release/docs/PIXI.Container.html) that is the root of the scene graph. Every child of the stage container will be rendered every frame. By adding our sprite to the stage, we tell PixiJS's renderer we want to draw it.
+Then we need to add our new sprite to the stage. The stage is simply a [Container](https://pixijs.download/v7.4.2/docs/PIXI.Container.html) that is the root of the scene graph. Every child of the stage container will be rendered every frame. By adding our sprite to the stage, we tell PixiJS's renderer we want to draw it.
 
 ```javascript
 app.stage.addChild(bunny)

--- a/src/tutorials/v8.0.0/chooChooTrain/step1/step1-content.md
+++ b/src/tutorials/v8.0.0/chooChooTrain/step1/step1-content.md
@@ -2,9 +2,9 @@
 
 Welcome to the Choo Choo Train workshop!
 
-We are going to handcraft a cute little scene of a train moving through a landscape at night. We will solely be using the [Graphics](https://pixijs.com/guides/components/graphics) API to draw out the whole scene. In this tutorial, we will be exploring a handful of methods it provides to draw a variety of shapes. For the full list of methods, please check out the Graphics [documentation](https://pixijs.download/release/docs/PIXI.Graphics.html).
+We are going to handcraft a cute little scene of a train moving through a landscape at night. We will solely be using the [Graphics](https://pixijs.com/guides/components/graphics) API to draw out the whole scene. In this tutorial, we will be exploring a handful of methods it provides to draw a variety of shapes. For the full list of methods, please check out the Graphics [documentation](https://pixijs.download/release/docs/scene.Graphics.html).
 
-Please go through the tutorial steps at your own pace and challenge yourself using the editor on the right hand side. Here PixiJS has already been included as guided under the [Getting Started](/guides/basics/getting-started#loading-pixijs) section. Let's start off by creation a PixiJS application, initialize it, add its canvas to the DOM, and preload the required assets ahead of the subsequent steps.
+Please go through the tutorial steps at your own pace and challenge yourself using the editor on the right hand side. Here PixiJS has already been included as guided under the [Getting Started](/8.x/guides/basics/getting-started#loading-pixijs) section. Let's start off by creation a PixiJS application, initialize it, add its canvas to the DOM, and preload the required assets ahead of the subsequent steps.
 
 We will be using an asynchronous immediately invoked function expression ([IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE)), but you are free to switch to use promises instead.
 

--- a/src/tutorials/v8.0.0/chooChooTrain/step10/step10-content.md
+++ b/src/tutorials/v8.0.0/chooChooTrain/step10/step10-content.md
@@ -1,5 +1,5 @@
 # You did it!
 
-Congratulations, hope you enjoyed the journey! Now you are an expert on the Graphics API. Make sure to explore other features that the API has to offer on the official [documentation](https://pixijs.download/release/docs/PIXI.Graphics.html), like the ability to cut shapes out from existing ones, advance lines and curves, using gradients or textures for fill and stroke - just to list a few.
+Congratulations, hope you enjoyed the journey! Now you are an expert on the Graphics API. Make sure to explore other features that the API has to offer on the official [documentation](https://pixijs.download/release/docs/scene.Graphics.html), like the ability to cut shapes out from existing ones, advance lines and curves, using gradients or textures for fill and stroke - just to list a few.
 
 Feel free to head back to the gallery and explore other tutorials.

--- a/src/tutorials/v8.0.0/fishPond/step1/step1-content.md
+++ b/src/tutorials/v8.0.0/fishPond/step1/step1-content.md
@@ -2,9 +2,9 @@
 
 Welcome to the Fish Pond workshop!
 
-We are going to build a virtual pond and fill them with a number of colorful fishes. In the process, we will be learning about basic manipulation of [Sprites](/guides/components/sprites), [TilingSprite](https://pixijs.download/release/docs/PIXI.TilingSprite.html) and Filter, specifically the [Displacement Filter](https://pixijs.download/release/docs/PIXI.DisplacementFilter.html).
+We are going to build a virtual pond and fill them with a number of colorful fishes. In the process, we will be learning about basic manipulation of [Sprites](/8.x/guides/components/sprites), [TilingSprite](https://pixijs.download/release/docs/scene.TilingSprite.html) and Filter, specifically the [Displacement Filter](https://pixijs.download/release/docs/filters.DisplacementFilter.html).
 
-Please go through the tutorial steps at your own pace and challenge yourself using the editor on the right hand side. Here PixiJS has already been included as guided under the [Getting Started](/guides/basics/getting-started#loading-pixijs) section. Let's start off by creation a PixiJS application, initialize it, add its canvas to the DOM, and preload the required assets ahead of the subsequent steps.
+Please go through the tutorial steps at your own pace and challenge yourself using the editor on the right hand side. Here PixiJS has already been included as guided under the [Getting Started](/8.x/guides/basics/getting-started#loading-pixijs) section. Let's start off by creation a PixiJS application, initialize it, add its canvas to the DOM, and preload the required assets ahead of the subsequent steps.
 
 We will be using an asynchronous immediately invoked function expression ([IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE)), but you are free to switch to use promises instead.
 

--- a/src/tutorials/v8.0.0/fishPond/step5/addDisplacementEffect-completed.js
+++ b/src/tutorials/v8.0.0/fishPond/step5/addDisplacementEffect-completed.js
@@ -12,8 +12,6 @@ export function addDisplacementEffect(app)
     const filter = new DisplacementFilter({
         sprite,
         scale: 50,
-        width: app.screen.width,
-        height: app.screen.height,
     });
 
     // Add the filter to the stage.

--- a/src/tutorials/v8.0.0/fishPond/step5/step5-content.md
+++ b/src/tutorials/v8.0.0/fishPond/step5/step5-content.md
@@ -18,8 +18,6 @@ From here, we can simply create the displacement filter and add it to the stage 
 const filter = new DisplacementFilter({
     sprite,
     scale: 50,
-    width: app.screen.width,
-    height: app.screen.height,
 });
 
 app.stage.filters = [filter];

--- a/src/tutorials/v8.0.0/gettingStarted/step1-content.md
+++ b/src/tutorials/v8.0.0/gettingStarted/step1-content.md
@@ -2,7 +2,7 @@
 
 Welcome to the PixiJS tutorial!
 
-Please go through the tutorial steps at your own pace and challenge yourself using the editor on the right hand side. Here PixiJS has already been included as guided under the [Getting Started](/guides/basics/getting-started#loading-pixijs) section. Let's start with the creation of a PixiJS canvas application and add its view to the DOM.
+Please go through the tutorial steps at your own pace and challenge yourself using the editor on the right hand side. Here PixiJS has already been included as guided under the [Getting Started](/8.x/guides/basics/getting-started#loading-pixijs) section. Let's start with the creation of a PixiJS canvas application and add its view to the DOM.
 
 We will be using an asynchronous immediately invoked function expression ([IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE)), but you are free to switch to use promises instead.
 

--- a/src/tutorials/v8.0.0/gettingStarted/step2-content.md
+++ b/src/tutorials/v8.0.0/gettingStarted/step2-content.md
@@ -2,7 +2,7 @@
 
 So far all we've been doing is prep work. We haven't actually told PixiJS to draw anything. Let's fix that by adding an image to be displayed.
 
-There are a number of ways to draw images in PixiJS, but the simplest is by using a [Sprite](https://pixijs.download/release/docs/PIXI.Sprite.html). We'll get into the details of how the scene graph works in a later guide, but for now all you need to know is that PixiJS renders a hierarchy of [Containers](https://pixijs.download/release/docs/PIXI.Container.html). A Sprite is an extension of Container that wraps a loaded image resource to allow drawing it, scaling it, rotating it, and so forth.
+There are a number of ways to draw images in PixiJS, but the simplest is by using a [Sprite](https://pixijs.download/release/docs/scene.Sprite.html). We'll get into the details of how the scene graph works in a later guide, but for now all you need to know is that PixiJS renders a hierarchy of [Containers](https://pixijs.download/release/docs/scene.Container.html). A Sprite is an extension of Container that wraps a loaded image resource to allow drawing it, scaling it, rotating it, and so forth.
 
 Before PixiJS can render an image, it needs to be loaded. Just like in any web page, image loading happens asynchronously. For now, we will simply load a single texture up on the spot with the `Assets` utility class.
 

--- a/src/tutorials/v8.0.0/index.ts
+++ b/src/tutorials/v8.0.0/index.ts
@@ -24,7 +24,7 @@ export default {
         thumbnail: 'thumb_spineboy_adventure.png',
         steps: spineBoyAdventureTutorialSteps,
         extraPackages: {
-            '@pixi/spine-pixi': '^1.0.4',
+            '@esotericsoftware/spine-pixi-v8': '^4.2.66',
         },
     },
 };

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step1/step1-code.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step1/step1-code.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step1/step1-content.md
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step1/step1-content.md
@@ -2,7 +2,7 @@
 
 Welcome to the SpineBoy Adventure workshop!
 
-Let's venture into the world of the PixiJS ecosystem. We are going to explore one of the official plugins; [Spine plugin (`@pixi/spine-pixi`)](https://github.com/pixijs/spine-v8) which allow us to render and manipulate Spine animations on our PixiJS.
+Let's venture into the world of the PixiJS ecosystem. We are going to explore one of the official plugins; [Spine plugin (`@esotericsoftware/spine-pixi-v8`)](https://github.com/EsotericSoftware/spine-runtimes/tree/4.2/spine-ts) which allow us to render and manipulate Spine animations on our PixiJS.
 
 We will be creating a mini interactive side-scroller experience using the famous SpineBoy which will be controlled by the keyboard. For the sake of simplicity, we will be focusing on just the movement around the scene.
 

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step2/SpineBoy1-completed.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step2/SpineBoy1-completed.js
@@ -1,4 +1,4 @@
-import { Spine } from '@pixi/spine-pixi';
+import { Spine } from '@esotericsoftware/spine-pixi-v8';
 import { Container } from 'pixi.js';
 
 // Class for handling the character Spine and its animations.

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step2/SpineBoy1.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step2/SpineBoy1.js
@@ -1,4 +1,4 @@
-import { Spine } from '@pixi/spine-pixi';
+import { Spine } from '@esotericsoftware/spine-pixi-v8';
 import { Container } from 'pixi.js';
 
 // Class for handling the character Spine and its animations.

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step2/step2-code-completed.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step2/step2-code-completed.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 import { SpineBoy } from './SpineBoy';

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step2/step2-code.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step2/step2-code.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 import { SpineBoy } from './SpineBoy';

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step3/step3-code-completed.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step3/step3-code-completed.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 import { SpineBoy } from './SpineBoy';

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step3/step3-code.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step3/step3-code.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 import { SpineBoy } from './SpineBoy';

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step4/SpineBoy2-completed.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step4/SpineBoy2-completed.js
@@ -1,4 +1,4 @@
-import { Spine } from '@pixi/spine-pixi';
+import { Spine } from '@esotericsoftware/spine-pixi-v8';
 import { Container } from 'pixi.js';
 
 // Define the Spine animation map for the character.

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step4/SpineBoy2.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step4/SpineBoy2.js
@@ -1,4 +1,4 @@
-import { Spine } from '@pixi/spine-pixi';
+import { Spine } from '@esotericsoftware/spine-pixi-v8';
 import { Container } from 'pixi.js';
 
 // Define the Spine animation map for the character.

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step4/step4-code-completed.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step4/step4-code-completed.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 import { SpineBoy } from './SpineBoy';

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step4/step4-code.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step4/step4-code.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 import { SpineBoy } from './SpineBoy';

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step5/step5-code.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step5/step5-code.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 import { SpineBoy } from './SpineBoy';

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step6/step6-code-completed.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step6/step6-code-completed.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 import { SpineBoy } from './SpineBoy';

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step6/step6-code.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step6/step6-code.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 import { SpineBoy } from './SpineBoy';

--- a/src/tutorials/v8.0.0/spineBoyAdventure/step7/step7-code.js
+++ b/src/tutorials/v8.0.0/spineBoyAdventure/step7/step7-code.js
@@ -1,4 +1,4 @@
-import '@pixi/spine-pixi';
+import '@esotericsoftware/spine-pixi-v8';
 
 import { Application, Assets } from 'pixi.js';
 import { SpineBoy } from './SpineBoy';

--- a/versioned_docs/version-7.x/guides/basics/getting-started.md
+++ b/versioned_docs/version-7.x/guides/basics/getting-started.md
@@ -31,7 +31,7 @@ OK!  With those notes out of the way, let's get started.  There are only a few s
 * Create an HTML file
 * Serve the file with a web server
 * Load the PixiJS library
-* Create an [Application](https://pixijs.download/release/docs/PIXI.Application.html)
+* Create an [Application](https://pixijs.download/v7.4.2/docs/PIXI.Application.html)
 * Add the generated view to the DOM
 * Add an image to the stage
 * Write an update loop
@@ -70,7 +70,7 @@ Test that everything is working by opening your browser of choice and entering `
 OK, so we have a web page, and we're serving it.  But it's empty.  The next step is to actually load the PixiJS library.  If we were building a real application, we'd want to download a target version of PixiJS from the [Pixi Github repo](https://github.com/pixijs/pixijs) so that our version wouldn't change on us.  But for this sample application, we'll just use the CDN version of PixiJS.  Add this line to the `<head>` section of your `index.html` file:
 
 ```html
-<script src="https://pixijs.download/release/pixi.js"></script>
+<script src="https://pixijs.download/v7.4.2/pixi.js"></script>
 ```
 
 This will include a *non-minified* version of the latest version of PixiJS when your page loads, ready to be used.  We use the non-minified version because we're in development.  In production, you'd want to use `pixi.min.js` instead, which is compressed for faster download and excludes assertions and deprecation warnings that can help when building your project, but take longer to download and run.
@@ -85,7 +85,7 @@ Loading the library doesn't do much good if we don't *use* it, so the next step 
 </script>
 ```
 
-What we're doing here is adding a JavaScript code block, and in that block creating a new PIXI.Application instance. [Application](https://pixijs.download/release/docs/PIXI.Application.html) is a helper class that simplifies working with PixiJS.  It creates the renderer, creates the stage, and starts a ticker for updating.  In production, you'll almost certainly want to do these steps yourself for added customization and control - we'll cover doing so in a later guide.  For now, the Application class is a perfect way to start playing with PixiJS without worrying about the details.
+What we're doing here is adding a JavaScript code block, and in that block creating a new PIXI.Application instance. [Application](https://pixijs.download/v7.4.2/docs/PIXI.Application.html) is a helper class that simplifies working with PixiJS.  It creates the renderer, creates the stage, and starts a ticker for updating.  In production, you'll almost certainly want to do these steps yourself for added customization and control - we'll cover doing so in a later guide.  For now, the Application class is a perfect way to start playing with PixiJS without worrying about the details.
 
 ### Adding the View to the DOM
 
@@ -101,7 +101,7 @@ This takes the view created by the application (the Canvas element) and adds it 
 
 So far all we've been doing is prep work.  We haven't actually told PixiJS to draw anything.  Let's fix that by adding an image to be displayed.
 
-There are a number of ways to draw images in PixiJS, but the simplest is by using a [Sprite](https://pixijs.download/release/docs/PIXI.Sprite.html).  We'll get into the details of how the scene graph works in a later guide, but for now all you need to know is that PixiJS renders a hierarchy of [DisplayObjects](https://pixijs.download/release/docs/PIXI.DisplayObject.html).  A Sprite is a type of DisplayObject that wraps a loaded image resource to allow drawing it, scaling it, rotating it, and so forth.
+There are a number of ways to draw images in PixiJS, but the simplest is by using a [Sprite](https://pixijs.download/v7.4.2/docs/PIXI.Sprite.html).  We'll get into the details of how the scene graph works in a later guide, but for now all you need to know is that PixiJS renders a hierarchy of [DisplayObjects](https://pixijs.download/v7.4.2/docs/PIXI.DisplayObject.html).  A Sprite is a type of DisplayObject that wraps a loaded image resource to allow drawing it, scaling it, rotating it, and so forth.
 
 Before PixiJS can render an image, it needs to be loaded.  Just like in any web page, image loading happens asynchronously.  We'll talk a lot more about resource loading in later guides.  For now, we can use a helper method on the PIXI.Sprite class to handle the image loading for us:
 
@@ -114,7 +114,7 @@ Before PixiJS can render an image, it needs to be loaded.  Just like in any web 
 
 ### Adding the Sprite to the Stage
 
-Finally, we need to add our new sprite to the stage.  The stage is simply a [Container](https://pixijs.download/release/docs/PIXI.Container.html) that is the root of the scene graph.  Every child of the stage container will be rendered every frame.  By adding our sprite to the stage, we tell PixiJS's renderer we want to draw it.
+Finally, we need to add our new sprite to the stage.  The stage is simply a [Container](https://pixijs.download/v7.4.2/docs/PIXI.Container.html) that is the root of the scene graph.  Every child of the stage container will be rendered every frame.  By adding our sprite to the stage, we tell PixiJS's renderer we want to draw it.
 
 ```javascript
   app.stage.addChild(sprite);
@@ -150,7 +150,7 @@ Here's the whole thing in one place.  Check your file and make sure it matches i
 <!doctype html>
 <html>
   <head>
-    <script src="https://pixijs.download/release/pixi.min.js"></script>
+    <script src="https://pixijs.download/v7.4.2/pixi.min.js"></script>
   </head>
   <body>
     <script>

--- a/versioned_docs/version-7.x/guides/basics/what-pixijs-is.md
+++ b/versioned_docs/version-7.x/guides/basics/what-pixijs-is.md
@@ -12,11 +12,11 @@ One of the major features that distinguishes PixiJS from other web-based renderi
 
 ## ... More Than Just Sprites
 
-Drawing images on a page can be handled with HTML5 and the DOM, so why use PixiJS?  Beyond performance, the answer is that PixiJS goes well beyond simple images.  Draw trails and tracks with [SimpleRope](https://pixijs.download/release/docs/PIXI.SimpleRope.html).  Draw polygons, lines, circles and other primitives with [Graphics](https://pixijs.download/release/docs/PIXI.Graphics.html). [Text](https://pixijs.download/release/docs/PIXI.Text.html) provides full text rendering support that's just as performant as sprites.  And even when drawing simple images, PixiJS natively supports spritesheets for efficient loading and ease of development.
+Drawing images on a page can be handled with HTML5 and the DOM, so why use PixiJS?  Beyond performance, the answer is that PixiJS goes well beyond simple images.  Draw trails and tracks with [SimpleRope](https://pixijs.download/v7.4.2/docs/PIXI.SimpleRope.html).  Draw polygons, lines, circles and other primitives with [Graphics](https://pixijs.download/v7.4.2/docs/PIXI.Graphics.html). [Text](https://pixijs.download/v7.4.2/docs/PIXI.Text.html) provides full text rendering support that's just as performant as sprites.  And even when drawing simple images, PixiJS natively supports spritesheets for efficient loading and ease of development.
 
 ## ... WebGL Native
 
-WebGL is the JavaScript API for accessing users' GPUs for fast rendering and advanced effects.  PixiJS leverages WebGL to display thousands of moving sprites efficiently even on mobile devices.  But using WebGL offers more than just speed.  By using the [Filter](https://pixijs.download/release/docs/PIXI.Filter.html) class, you can write shader programs (or use pre-built ones!) to achieve displacement maps, blurring, and other advanced visual effects that cannot be accomplished with just the DOM or Canvas APIs.
+WebGL is the JavaScript API for accessing users' GPUs for fast rendering and advanced effects.  PixiJS leverages WebGL to display thousands of moving sprites efficiently even on mobile devices.  But using WebGL offers more than just speed.  By using the [Filter](https://pixijs.download/v7.4.2/docs/PIXI.Filter.html) class, you can write shader programs (or use pre-built ones!) to achieve displacement maps, blurring, and other advanced visual effects that cannot be accomplished with just the DOM or Canvas APIs.
 
 ## ... Open Source
 

--- a/versioned_docs/version-7.x/guides/components/containers.md
+++ b/versioned_docs/version-7.x/guides/components/containers.md
@@ -1,6 +1,6 @@
 # Containers
 
-The [Container](https://pixijs.download/release/docs/PIXI.Container.html) class provides a simple display object that does what its name implies - collect a set of child objects together.  But beyond grouping objects, containers have a few uses that you should be aware of.
+The [Container](https://pixijs.download/v7.4.2/docs/PIXI.Container.html) class provides a simple display object that does what its name implies - collect a set of child objects together.  But beyond grouping objects, containers have a few uses that you should be aware of.
 
 ## Containers as Groups
 
@@ -74,9 +74,9 @@ app.ticker.add((delta) => {
 
 There are two types of masks supported by PixiJS:
 
-Use a [Graphics](https://pixijs.download/release/docs/PIXI.Graphics.html) object to create a mask with an arbitrary shape - powerful, but doesn't support anti-aliasing
+Use a [Graphics](https://pixijs.download/v7.4.2/docs/PIXI.Graphics.html) object to create a mask with an arbitrary shape - powerful, but doesn't support anti-aliasing
 
-Sprite: Use the alpha channel from a [Sprite](https://pixijs.download/release/docs/PIXI.Sprite.html) as your mask, providing anti-aliased edging - _not_ supported on the Canvas renderer
+Sprite: Use the alpha channel from a [Sprite](https://pixijs.download/v7.4.2/docs/PIXI.Sprite.html) as your mask, providing anti-aliased edging - _not_ supported on the Canvas renderer
 
 ## Filtering
 

--- a/versioned_docs/version-7.x/guides/components/display-object.md
+++ b/versioned_docs/version-7.x/guides/components/display-object.md
@@ -1,6 +1,6 @@
 # Display Objects
 
-[DisplayObject](https://pixijs.download/release/docs/PIXI.DisplayObject.html) is the core class for anything that can be rendered by the engine.  It's the base class for sprites, text, complex graphics, containers, etc., and provides much of the common functionality for those objects.  As you're learning PixiJS, it's important to [read through the documentation for this class](https://pixijs.download/release/docs/PIXI.DisplayObject.html) to understand how to move, scale, rotate and compose the visual elements of your project.
+[DisplayObject](https://pixijs.download/v7.4.2/docs/PIXI.DisplayObject.html) is the core class for anything that can be rendered by the engine.  It's the base class for sprites, text, complex graphics, containers, etc., and provides much of the common functionality for those objects.  As you're learning PixiJS, it's important to [read through the documentation for this class](https://pixijs.download/v7.4.2/docs/PIXI.DisplayObject.html) to understand how to move, scale, rotate and compose the visual elements of your project.
 
 Be aware that you won't use DisplayObject directly - you'll use its functions and attributes in derived classes.
 

--- a/versioned_docs/version-7.x/guides/components/graphics.md
+++ b/versioned_docs/version-7.x/guides/components/graphics.md
@@ -1,6 +1,6 @@
 # Graphics
 
-[Graphics](https://pixijs.download/release/docs/PIXI.Graphics.html) is a complex and much misunderstood tool in the PixiJS toolbox.  At first glance, it looks like a tool for drawing shapes.  And it is!  But it can also be used to generate masks.  How does that work?
+[Graphics](https://pixijs.download/v7.4.2/docs/PIXI.Graphics.html) is a complex and much misunderstood tool in the PixiJS toolbox.  At first glance, it looks like a tool for drawing shapes.  And it is!  But it can also be used to generate masks.  How does that work?
 
 In this guide, we're going to de-mystify the Graphics object, starting with how to think about what it does.
 
@@ -53,7 +53,7 @@ In addition, the Graphics Extras package (`@pixi/graphics-extras`) optionally in
 
 ## The Geometry List
 
-Inside every Graphics object is a GraphicsGeometry object.  The [GraphicsGeometry](https://pixijs.download/release/docs/PIXI.GraphicsGeometry.html) class manages the list of geometry primitives created by the Graphics parent object.  For the most part, you will not work directly with this object.  The owning Graphics object creates and manages it.  However, there are two related cases where you *do* work with the list.
+Inside every Graphics object is a GraphicsGeometry object.  The [GraphicsGeometry](https://pixijs.download/v7.4.2/docs/PIXI.GraphicsGeometry.html) class manages the list of geometry primitives created by the Graphics parent object.  For the most part, you will not work directly with this object.  The owning Graphics object creates and manages it.  However, there are two related cases where you *do* work with the list.
 
 First, you can re-use geometry from one Graphics object in another.  No matter whether you're re-drawing the same shape over and over, or re-using it as a mask over and over, it's more efficient to share identical GraphicsGeometry.  You can do this like so:
 

--- a/versioned_docs/version-7.x/guides/components/interaction.md
+++ b/versioned_docs/version-7.x/guides/components/interaction.md
@@ -28,7 +28,7 @@ PixiJS supports the following event types:
 | `globalpointermove` | Fired when a pointer device is moved, regardless of hit-testing the current object. |
 | `pointerout` | Fired when a pointer device is moved off the display object. |
 | `pointerover` | Fired when a pointer device is moved onto the display object. |
-| `pointertap` | Fired when a pointer device is tapped twice on the display object. |
+| `pointertap` | Fired when a pointer device is tapped on the display object. |
 | `pointerup` | Fired when a pointer device button is released over the display object. |
 | `pointerupoutside` | Fired when a pointer device button is released outside the display object that initially registered a pointerdown. |
 | `mousedown ` | Fired when a mouse button is pressed on the display object. |
@@ -47,7 +47,7 @@ PixiJS supports the following event types:
 | `touchmove ` | Fired when a touch point is moved along the display object. |
 | `globaltouchmove` | Fired when a touch point is moved, regardless of hit-testing the current object. |
 | `touchstart ` | Fired when a touch point is placed on the display object. |
-| `tap ` | Fired when a touch point is tapped twice on the display object. |
+| `tap ` | Fired when a touch point is tapped on the display object. |
 | `wheel ` | Fired when a mouse wheel is spun over the display object. |
 | `rightclick ` | Fired when a right mouse button is clicked (pressed and released) over the display object. |
 | `rightdown ` | Fired when a right mouse button is pressed on the display object. |
@@ -69,7 +69,7 @@ sprite.on('pointerdown', (event) => { alert('clicked!'); });
 sprite.eventMode = 'static';
 ```
 
-Check out the [DisplayObject](https://pixijs.download/release/docs/PIXI.DisplayObject.html) for the list of interaction events supported.
+Check out the [DisplayObject](https://pixijs.download/v7.4.2/docs/PIXI.DisplayObject.html) for the list of interaction events supported.
 
 ### Checking if Object is Interactive
 

--- a/versioned_docs/version-7.x/guides/components/sprite-sheets.md
+++ b/versioned_docs/version-7.x/guides/components/sprite-sheets.md
@@ -1,6 +1,6 @@
 # Spritesheets
 
-Now that you understand basic sprites, it's time to talk about a better way to create them - the [Spritesheet](https://pixijs.download/release/docs/PIXI.Spritesheet.html) class.
+Now that you understand basic sprites, it's time to talk about a better way to create them - the [Spritesheet](https://pixijs.download/v7.4.2/docs/PIXI.Spritesheet.html) class.
 
 A Spritesheet is a media format for more efficiently downloading and rendering Sprites.  While somewhat more complex to create and use, they are a key tool in optimizing your project.
 

--- a/versioned_docs/version-7.x/guides/components/sprites.md
+++ b/versioned_docs/version-7.x/guides/components/sprites.md
@@ -1,6 +1,6 @@
 # Sprites
 
-Sprites are the simplest and most common renderable object in PixiJS.  They represent a single image to be displayed on the screen.  Each [Sprite](https://pixijs.download/release/docs/PIXI.Sprite.html) contains a [Texture](https://pixijs.download/release/docs/PIXI.Texture.html) to be drawn, along with all the transformation and display state required to function in the scene graph.
+Sprites are the simplest and most common renderable object in PixiJS.  They represent a single image to be displayed on the screen.  Each [Sprite](https://pixijs.download/v7.4.2/docs/PIXI.Sprite.html) contains a [Texture](https://pixijs.download/v7.4.2/docs/PIXI.Texture.html) to be drawn, along with all the transformation and display state required to function in the scene graph.
 
 ## Creating Sprites
 

--- a/versioned_docs/version-7.x/guides/components/text.md
+++ b/versioned_docs/version-7.x/guides/components/text.md
@@ -10,7 +10,7 @@ Because of the challenges of working with text in WebGL, PixiJS provides two ver
 
 ## The Text Object
 
-In order to draw text to the screen, you use a [Text](https://pixijs.download/release/docs/PIXI.Text.html) object.  Under the hood, this class draws text to an off-screen buffer using the browser's normal text rendering, then uses that offscreen buffer as the source for drawing the text object.  Effectively what this means is that whenever you create or change text, PixiJS creates a new rasterized image of that text, and then treats it like a sprite.  This approach allows truly rich text display while keeping rendering speed high.
+In order to draw text to the screen, you use a [Text](https://pixijs.download/v7.4.2/docs/PIXI.Text.html) object.  Under the hood, this class draws text to an off-screen buffer using the browser's normal text rendering, then uses that offscreen buffer as the source for drawing the text object.  Effectively what this means is that whenever you create or change text, PixiJS creates a new rasterized image of that text, and then treats it like a sprite.  This approach allows truly rich text display while keeping rendering speed high.
 
 So when working with PIXI.Text objects, there are two sets of options - standard display object options like position, rotation, etc that work *after* the text is rasterized internally, and text style options that are used *while* rasterizing.  Because text once rendered is basically just a sprite, there's no need to review the standard options.  Instead, let's focus on how text is styled.
 
@@ -18,7 +18,7 @@ Check out the [text example code](../../examples/text/pixi-text).
 
 ## Text Styles
 
-There are a lot of text style options available (see [TextStyle](https://pixijs.download/release/docs/PIXI.TextStyle.html)), but they break down into 5 main groups:
+There are a lot of text style options available (see [TextStyle](https://pixijs.download/v7.4.2/docs/PIXI.TextStyle.html)), but they break down into 5 main groups:
 
 **Font**: `fontFamily` to select the webfont to use, `fontSize` to specify the size of the text to draw, along with options for font weight, style and variant.
 

--- a/versioned_docs/version-7.x/guides/components/textures.md
+++ b/versioned_docs/version-7.x/guides/components/textures.md
@@ -20,7 +20,7 @@ To work with the image, the first step is to pull the image file from your webse
 
 ### BaseTextures Own the Data
 
-Once the Loader has done its work, the loaded `<IMG>` element contains the pixel data we need.  But to use it to render something, PixiJS has to take that raw image file and upload it to the GPU.  This brings us to the real workhorse of the texture system - the [BaseTexture](https://pixijs.download/release/docs/PIXI.BaseTexture.html) class.  Each BaseTexture manages a single pixel source - usually an image, but can also be a Canvas or Video element.  BaseTextures allow PixiJS to convert the image to pixels and use those pixels in rendering.  In addition, it also contains settings that control how the texture data is rendered, such as the wrap mode (for UV coordinates outside the 0.0-1.0 range) and scale mode (used when scaling a texture).
+Once the Loader has done its work, the loaded `<IMG>` element contains the pixel data we need.  But to use it to render something, PixiJS has to take that raw image file and upload it to the GPU.  This brings us to the real workhorse of the texture system - the [BaseTexture](https://pixijs.download/v7.4.2/docs/PIXI.BaseTexture.html) class.  Each BaseTexture manages a single pixel source - usually an image, but can also be a Canvas or Video element.  BaseTextures allow PixiJS to convert the image to pixels and use those pixels in rendering.  In addition, it also contains settings that control how the texture data is rendered, such as the wrap mode (for UV coordinates outside the 0.0-1.0 range) and scale mode (used when scaling a texture).
 
 BaseTextures are automatically cached, so that calling `PIXI.Texture.from()` repeatedly for the same URL returns the same BaseTexture each time.  Destroying a BaseTexture frees the image data associated with it.
 
@@ -28,7 +28,7 @@ BaseTextures are automatically cached, so that calling `PIXI.Texture.from()` rep
 
 So finally, we get to the PIXI.Texture class itself!  At this point, you may be wondering what the Texture object *does*.  After all, the BaseTexture manages the pixels and render settings.  And the answer is, it doesn't do very much.  Textures are light-weight views on an underlying BaseTexture.  Their main attribute is the source rectangle within the BaseTexture from which to pull.
 
-If all PixiJS drew were sprites, that would be pretty redundant.  But consider [SpriteSheets](./sprite-sheets).  A SpriteSheet is a single image that contains multiple sprite images arranged within.  In a [Spritesheet](https://pixijs.download/release/docs/PIXI.Spritesheet.html) object, a single BaseTexture is referenced by a set of Textures, one for each source image in the original sprite sheet.  By sharing a single BaseTexture, the browser only downloads one file, and our batching renderer can blaze through drawing sprites since they all share the same underlying pixel data.  The SpriteSheet's Textures pull out just the rectangle of pixels needed by each sprite.
+If all PixiJS drew were sprites, that would be pretty redundant.  But consider [SpriteSheets](./sprite-sheets).  A SpriteSheet is a single image that contains multiple sprite images arranged within.  In a [Spritesheet](https://pixijs.download/v7.4.2/docs/PIXI.Spritesheet.html) object, a single BaseTexture is referenced by a set of Textures, one for each source image in the original sprite sheet.  By sharing a single BaseTexture, the browser only downloads one file, and our batching renderer can blaze through drawing sprites since they all share the same underlying pixel data.  The SpriteSheet's Textures pull out just the rectangle of pixels needed by each sprite.
 
 <!--TODO: Image showing sprite sheet base texture, plus each sprite's texture-->
 
@@ -50,7 +50,7 @@ Instead, here's a quick cheat sheet of one good solution:
 
 Using this workflow ensures that your textures are pre-loaded, to prevent pop-in, and is relatively easy to code.
 
-Regarding preparing textures: Even after you've loaded your textures, the images still need to be pushed to the GPU and decoded.  Doing this for a large number of source images can be slow and cause lag spikes when your project first loads.  To solve this, you can use the [Prepare](https://pixijs.download/release/docs/PIXI.Prepare.html) plugin, which allows you to pre-load textures in a final step before displaying your project.
+Regarding preparing textures: Even after you've loaded your textures, the images still need to be pushed to the GPU and decoded.  Doing this for a large number of source images can be slow and cause lag spikes when your project first loads.  To solve this, you can use the [Prepare](https://pixijs.download/v7.4.2/docs/PIXI.Prepare.html) plugin, which allows you to pre-load textures in a final step before displaying your project.
 
 ## Unloading Textures
 
@@ -68,7 +68,7 @@ Canvas: Similarly, you can wrap an HTML5 `<CANVAS>` element in a BaseTexture to 
 
 SVG: Pass in an `<SVG>` element or load a .svg URL, and PixiJS will attempt to rasterize it.  For highly network-constrained projects, this can allow for beautiful graphics with minimal network load times.
 
-RenderTexture: A more advanced (but very powerful!) feature is to build a Texture from a [RenderTexture](https://pixijs.download/release/docs/PIXI.RenderTexture.html).  This can allow for building complex geometry using a [Geometry](https://pixijs.download/release/docs/PIXI.Geometry.html) object, then baking that geometry down to a simple texture.
+RenderTexture: A more advanced (but very powerful!) feature is to build a Texture from a [RenderTexture](https://pixijs.download/v7.4.2/docs/PIXI.RenderTexture.html).  This can allow for building complex geometry using a [Geometry](https://pixijs.download/v7.4.2/docs/PIXI.Geometry.html) object, then baking that geometry down to a simple texture.
 
 Each of these texture sources has caveats and nuances that we can't cover in this guide, but they should give you a feeling for the power of PixiJS's texture system. <!--TODO: link to advanced textures guide-->
 

--- a/versioned_docs/version-7.x/guides/index.md
+++ b/versioned_docs/version-7.x/guides/index.md
@@ -1,6 +1,6 @@
 # Welcome
 
-PixiJS is an open source, web-based rendering system that provides blazing fast performance for games, data visualization, and other graphics intensive projects. These guides are designed to be a companion to the [API documentation](https://pixijs.download/release/docs/index.html), providing a structured introduction to using the API to solve problems and build projects.
+PixiJS is an open source, web-based rendering system that provides blazing fast performance for games, data visualization, and other graphics intensive projects. These guides are designed to be a companion to the [API documentation](https://pixijs.download/v7.4.2/docs/index.html), providing a structured introduction to using the API to solve problems and build projects.
 
 ## About The Guides
 
@@ -10,5 +10,5 @@ If you're new to PixiJS, we suggest you start with the Basics and read through t
 
 As you explore the guides, you may find these resources valuable:
 
-* [PixiJS API documentation](https://pixijs.download/release/docs)
+* [PixiJS API documentation](https://pixijs.download/v7.4.2/docs)
 * [PixiJS Github repo](https://github.com/pixijs/pixijs)

--- a/versioned_docs/version-7.x/guides/migrations/v5.md
+++ b/versioned_docs/version-7.x/guides/migrations/v5.md
@@ -37,7 +37,7 @@ PIXI.settings.PREFER_ENV = PIXI.ENV.WEBGL;
 
 PixiJS v5 introduces a new class called `PIXI.Mesh`. This allows overriding the default shader and the ability to add more attributes to geometry. For [example](https://pixijs.io/examples/#/mesh/triangle-textured.js), you can add colors to vertices.
 
-The old v4 Mesh class has moved from `PIXI.mesh.Mesh` to [`PIXI.SimpleMesh`](http://pixijs.download/dev/docs/PIXI.SimpleMesh.html), it extends `PIXI.Mesh`.
+The old v4 Mesh class has moved from `PIXI.mesh.Mesh` to [`PIXI.SimpleMesh`](http://pixijs.download/v5.3.12/docs/PIXI.SimpleMesh.html), it extends `PIXI.Mesh`.
 
 `PIXI.mesh.Rope`, `PIXI.mesh.Plane`, `PIXI.mesh.NineSlicePlane` have moved to `PIXI.SimpleRope`, `PIXI.SimplePlane` and `PIXI.NineSlicePlane` respectively.
 
@@ -123,7 +123,7 @@ In v5, this code is no longer needed.
 
 One of the newest features in v5 is that we decoupled all the asset-specific functionality from BaseTexture. We created a new system called "resources" and each BaseTexture now has a resource that wraps some specific asset type. For instance: VideoResource, SVGResource, ImageResource, CanvasResource. In the future, we hope to be able to add other resource types. If there were asset-specific methods or properties being called before, these will probably be on `baseTexture.resource`.
 
-Also, we removed all of the `from*` methods from BaseTexture, so you just can call `BaseTexture.from` and pass in whatever resource. Please see [docs](http://pixijs.download/dev/docs/PIXI.BaseTexture.html) for more information about `from`.
+Also, we removed all of the `from*` methods from BaseTexture, so you just can call `BaseTexture.from` and pass in whatever resource. Please see [docs](http://pixijs.download/v5.3.12/docs/PIXI.BaseTexture.html) for more information about `from`.
 
 ```js
 const canvas = document.createElement('canvas');


### PR DESCRIPTION
- fixes: 
  - #135
  - #133
  - #51
- fixes all of the links in the v7 docs to point to a stable v7 version
- updates website to 8.6.0
- fixes description meta data for teams page
- updates spine tutorial to use esoterics package