### PR TITLE
feat: Add text labels to blend-mode examples

### DIFF
--- a/src/examples/v8.0.0/basic/blendModes.js
+++ b/src/examples/v8.0.0/basic/blendModes.js
@@ -1,6 +1,6 @@
 import 'pixi.js/advanced-blend-modes';
 
-import { Application, Assets, Container, Sprite } from 'pixi.js';
+import { Application, Assets, Container, Sprite, Text, Texture } from 'pixi.js';
 
 (async () =>
 {
@@ -76,6 +76,25 @@ import { Application, Assets, Container, Sprite } from 'pixi.js';
         });
 
         container.addChild(sprite, sprite2);
+
+        const text = new Text({
+            text: allBlendModes[i],
+            style: {
+                fontSize: 16,
+                fontFamily: 'short-stack',
+            },
+        });
+
+        // Add blend mode text labels
+        text.x = size / 2 - text.width / 2;
+        text.y = size - text.height;
+        const textBackground = new Sprite(Texture.WHITE);
+
+        textBackground.x = text.x - 2;
+        textBackground.y = text.y;
+        textBackground.width = text.width + 4;
+        textBackground.height = text.height + 4;
+        container.addChild(textBackground, text);
 
         app.stage.addChild(container);
 


### PR DESCRIPTION
A little quality-of-life improvement for folks browsing the examples, or who want to see the different blend modes in action for comparison.

From unlabeled: 

![image](https://github.com/user-attachments/assets/29e0aaf4-1b72-42fa-9a4f-e552892a0007)

To labeled:

![image](https://github.com/user-attachments/assets/c31e7847-da15-4700-a4ab-d19b788a2044)
