### PR TITLE
Fix typo in v8 migration guide

### DIFF
--- a/docs/guides/migrations/v8.md
+++ b/docs/guides/migrations/v8.md
@@ -188,7 +188,7 @@ const graphics = new Graphics()
   .drawRect(50, 50, 100, 100)
   .endFill();
 
-// blur rect with stroke
+// blue rect with stroke
 const graphics2 = new Graphics()
   .lineStyle(2, 'white')
   .beginFill('blue')
@@ -204,7 +204,7 @@ const graphics = new Graphics()
   .fill(0xFF0000);
 
 
-// blur rect with stroke
+// blue rect with stroke
 const graphics2 = new Graphics()
   .rect(50, 50, 100, 100)
   .fill('blue')


### PR DESCRIPTION
Replace "blur" with "blue".