### PR TITLE
fix formatting and typos in v8 migration guide

### DIFF
--- a/docs/guides/migrations/v8.md
+++ b/docs/guides/migrations/v8.md
@@ -30,7 +30,7 @@ We are working hard to migrate our key libraries to v8 but did not want this to 
  - Gif
  - Storybook
  - UI
- -  - Open Games
+ - Open Games
 
 **Migrating Right Now:**
  - React
@@ -132,31 +132,31 @@ PixiJS will now need to be initialised asynchronously. With the introduction of 
   })()
   ```
 
-  With this change it also means that the `ApplicationOptions` object can now be passed into the `init` function instead of the constructor.
+With this change it also means that the `ApplicationOptions` object can now be passed into the `init` function instead of the constructor.
 
-### ** Texture adjustments **
+
+### **Texture adjustments**
 
 Textures structures have been modified to simplify what was becoming quite a mess behind the scenes in v7.
 Textures no longer know or manage loading of resources. This needs to be done upfront by you or the assets manager. Textures expect full loaded resources only. This makes things so much easier to manage as the validation of a texture can essentially be done at construction time and left at that!
+
 BaseTexture no longer exists. In stead we now have a variety of TextureSources available. A texture source combines the settings of a texture with how to upload and use that texture. In v8 there are the following texture sources:
 
-TextureSource - a vanilla texture that you can render too or upload however you wish. (used mainly by render textures)
-ImageSource - a texture source that contains an image resource of some kind (eg ImageBitmap or html image)
-CanvasSource - a canvas source that contains a canvas. Used mainly for rendering canvases or rendering to a canvas (webGPU)
-VideoSource - a texture source that contains a video. Takes care of updating the texture eon the GPU to ensure that they stay in sync.
-BufferSource - a texture source that contains a buffer. What ever you want really! make sure your buffer type and format are compatible!
-CompressedSource - a texture source that handles compressed textures. Used by the GPU compressed texture formats.
+- TextureSource - a vanilla texture that you can render to or upload however you wish. (used mainly by render textures)
+- ImageSource - a texture source that contains an image resource of some kind (eg ImageBitmap or html image)
+- CanvasSource - a canvas source that contains a canvas. Used mainly for rendering canvases or rendering to a canvas (webGPU)
+- VideoSource - a texture source that contains a video. Takes care of updating the texture on the GPU to ensure that they stay in sync.
+- BufferSource - a texture source that contains a buffer. What ever you want really! make sure your buffer type and format are compatible!
+- CompressedSource - a texture source that handles compressed textures. Used by the GPU compressed texture formats.
 
 Whilst the majority of the time `Assets` will return Textures you may want to make you own! More power to ya!
 
 To create a texture source the signature differs from baseTexture. example:
 
-```
-
+```ts
 const image = new Image();
 
 image.onload = function(){
-
   // create a texture source
   const source = new ImageSource({
     resource: image,
@@ -169,7 +169,6 @@ image.onload = function(){
 }
 
 image.src = 'myImage.png';
-
 ```
 
 
@@ -180,140 +179,141 @@ There are a few key changes to the Graphics API. In fact this is probably the mo
 
 - Instead of beginning a fill or a stroke and then building a shape, v8 asks you to build your shape and then stroke / fill it. The terminology of `Line` has been replaced with the terminology of `Stroke`
 
-**Old:**
-```ts
-// red rect
-const graphics = new Graphics()
-  .beginFill(0xFF0000)
-  .drawRect(50, 50, 100, 100)
-  .endFill();
-
-// blur rect with stroke
-const graphics2 = new Graphics()
-  .lineStyle(2, 'white')
-  .beginFill('blue')
-  .circle(530, 50, 140, 100)
-  .endFill();
-
-```
-**New:**
-```ts
-// red rect
-const graphics = new Graphics()
-  .rect(50, 50, 100, 100)
-  .fill(0xFF0000);
-
-
-// blur rect with stroke
-const graphics2 = new Graphics()
-  .rect(50, 50, 100, 100)
-  .fill('blue')
-  .stroke({width:2, color:'white'});
-```
-
-- Shape functions have been renamed. Each drawing function has been simplified into a shorter version of its name. They have the same parameters though:
-
-| v7 API Call            | v8 API Equivalent |
-|------------------------|-------------------|
-| drawChamferRect        | chamferRect       |
-| drawCircle             | circle            |
-| drawEllipse            | ellipse           |
-| drawFilletRect         | filletRect        |
-| drawPolygon            | poly              |
-| drawRect               | rect              |
-| drawRegularPolygon     | regularPoly       |
-| drawRoundedPolygon     | roundPoly         |
-| drawRoundedRect        | roundRect         |
-| drawRoundedShape       | roundShape        |
-| drawStar               | star              |
-
-- fills functions expect `FillStyle` options or a color, rather than a string of parameters. This also replaces `beginTextureFill`
-
-**Old:**
-```ts
-  const rect = new Graphics()
-    .beginTextureFill({texture:Texture.WHITE, alpha:0.5, color:0xFF0000})
-    .drawRect(0, 0, 100, 100)
-    .endFill()
-    .beginFill(0xFFFF00, 0.5)
-    .drawRect(100, 0, 100, 100)
+  **Old:**
+  ```ts
+  // red rect
+  const graphics = new Graphics()
+    .beginFill(0xFF0000)
+    .drawRect(50, 50, 100, 100)
     .endFill();
 
-```
-**New:**
-```ts
-  const rect = new Graphics()
-   .rect(0, 0, 100, 100)
-   .fill({texture:Texture.WHITE, alpha:0.5, color:0xFF0000})
-   .rect(100, 0, 100, 100)
-   .fill({color:0xFFFF00, alpha:0.5});
-```
-
-- stokes functions expect `StrokeStyle` options or a color, rather than a string of parameters. This also replaces `lineTextureStyle`
-**Old:**
-```ts
-  const rect = new Graphics()
-    .lineTextureStyle({texture:Texture.WHITE, width:10, color:0xFF0000})
-    .drawRect(0, 0, 100, 100)
-    .endFill()
-    .lineStyle(2, 0xFEEB77);
-    .drawRect(100, 0, 100, 100)
+  // blur rect with stroke
+  const graphics2 = new Graphics()
+    .lineStyle(2, 'white')
+    .beginFill('blue')
+    .circle(530, 50, 140, 100)
     .endFill();
 
-```
-**New:**
-```ts
-  const rect = new Graphics()
-   .rect(0, 0, 100, 100)
-   .stroke({texture:Texture.WHITE,  width:10, color:0xFF0000})
-   .rect(100, 0, 100, 100)
-   .stroke({color:0xFEEB77, width:2});
-```
-
-- holes now make use of a new `cut` function. As with `stroke` and `fill`, `cut` acts on the previous shape.
-**Old:**
-```ts
-  const rectAndHole = new Graphics()
-    .beginFill(0x00FF00)
-    .drawRect(0, 0, 100, 100)
-    .beginHole()
-    .drawCircle(50, 50, 20)
-    .endHole()
-    .endFill();
-```
-**New:**
-```ts
-  const rectAndHole = new Graphics()
-   .rect(0, 0, 100, 100)
-   .fill(0x00FF00)
-   .circle(50, 50, 20)
-   .cut();
-```
-
-
-- `GraphicsGeometry` has been replaced with `GraphicsContext` this allows for sharing of `Graphics` data more efficiently.
-
-**Old:**
-```ts
-  const rect = new Graphics()
-  .beginFill(0xFF0000)
-  .drawRect(50, 50, 100, 100)
-  .endFill();
-
-  const geometry = rect.geometry;
-
-  const secondRect = new Graphics(geometry);
-
-```
-**New:**
-```ts
-  const context = new GraphicsContext()
+  ```
+  **New:**
+  ```ts
+  // red rect
+  const graphics = new Graphics()
     .rect(50, 50, 100, 100)
     .fill(0xFF0000);
 
-  const rect = new Graphics(context);
-  const secondRect = new Graphics(context);
-```
+
+  // blur rect with stroke
+  const graphics2 = new Graphics()
+    .rect(50, 50, 100, 100)
+    .fill('blue')
+    .stroke({width:2, color:'white'});
+  ```
+
+- Shape functions have been renamed. Each drawing function has been simplified into a shorter version of its name. They have the same parameters though:
+
+  | v7 API Call            | v8 API Equivalent |
+  |------------------------|-------------------|
+  | drawChamferRect        | chamferRect       |
+  | drawCircle             | circle            |
+  | drawEllipse            | ellipse           |
+  | drawFilletRect         | filletRect        |
+  | drawPolygon            | poly              |
+  | drawRect               | rect              |
+  | drawRegularPolygon     | regularPoly       |
+  | drawRoundedPolygon     | roundPoly         |
+  | drawRoundedRect        | roundRect         |
+  | drawRoundedShape       | roundShape        |
+  | drawStar               | star              |
+
+- fills functions expect `FillStyle` options or a color, rather than a string of parameters. This also replaces `beginTextureFill`
+
+  **Old:**
+  ```ts
+    const rect = new Graphics()
+      .beginTextureFill({texture:Texture.WHITE, alpha:0.5, color:0xFF0000})
+      .drawRect(0, 0, 100, 100)
+      .endFill()
+      .beginFill(0xFFFF00, 0.5)
+      .drawRect(100, 0, 100, 100)
+      .endFill();
+
+  ```
+  **New:**
+  ```ts
+    const rect = new Graphics()
+     .rect(0, 0, 100, 100)
+     .fill({texture:Texture.WHITE, alpha:0.5, color:0xFF0000})
+     .rect(100, 0, 100, 100)
+     .fill({color:0xFFFF00, alpha:0.5});
+  ```
+
+- stroke functions expect `StrokeStyle` options or a color, rather than a string of parameters. This also replaces `lineTextureStyle`
+
+  **Old:**
+  ```ts
+    const rect = new Graphics()
+      .lineTextureStyle({texture:Texture.WHITE, width:10, color:0xFF0000})
+      .drawRect(0, 0, 100, 100)
+      .endFill()
+      .lineStyle(2, 0xFEEB77);
+      .drawRect(100, 0, 100, 100)
+      .endFill();
+
+  ```
+  **New:**
+  ```ts
+    const rect = new Graphics()
+     .rect(0, 0, 100, 100)
+     .stroke({texture:Texture.WHITE,  width:10, color:0xFF0000})
+     .rect(100, 0, 100, 100)
+     .stroke({color:0xFEEB77, width:2});
+  ```
+
+- holes now make use of a new `cut` function. As with `stroke` and `fill`, `cut` acts on the previous shape.
+
+  **Old:**
+  ```ts
+    const rectAndHole = new Graphics()
+      .beginFill(0x00FF00)
+      .drawRect(0, 0, 100, 100)
+      .beginHole()
+      .drawCircle(50, 50, 20)
+      .endHole()
+      .endFill();
+  ```
+  **New:**
+  ```ts
+    const rectAndHole = new Graphics()
+     .rect(0, 0, 100, 100)
+     .fill(0x00FF00)
+     .circle(50, 50, 20)
+     .cut();
+  ```
+
+- `GraphicsGeometry` has been replaced with `GraphicsContext` this allows for sharing of `Graphics` data more efficiently.
+
+  **Old:**
+  ```ts
+    const rect = new Graphics()
+    .beginFill(0xFF0000)
+    .drawRect(50, 50, 100, 100)
+    .endFill();
+
+    const geometry = rect.geometry;
+
+    const secondRect = new Graphics(geometry);
+
+  ```
+  **New:**
+  ```ts
+    const context = new GraphicsContext()
+      .rect(50, 50, 100, 100)
+      .fill(0xFF0000);
+
+    const rect = new Graphics(context);
+    const secondRect = new Graphics(context);
+  ```
 
 ### Shader changes
 As we now need to accommodate both WebGL and WebGPU shaders, the wey they are constructed has been tweaked to take this into account. The main differences you will notice (this is for shaders in general) is that Textures are no longer considered uniforms (as in they cannot be included in a uniform group). Instead we have the concept of resources. A resource can be a few things including:
@@ -325,12 +325,12 @@ As we now need to accommodate both WebGL and WebGPU shaders, the wey they are co
 
 creating a webgl only shader now looks like this:
 
-**old**
+**Old**
 ```ts
 const shader = PIXI.Shader.from(vertex, fragment, uniforms);
 ```
-**new**
 
+**New**
 just WebGL
 ```ts
 const shader = Shader.from({
@@ -359,7 +359,7 @@ const shader = Shader.from({
 
 Uniforms are also constructed in a slightly different way. When creating them, you now provide the type of variable you want it to be.
 
-**old**
+**Old**
 ```ts
 const uniformGroup = new UniformGroup({
   uTime:1,
@@ -368,10 +368,10 @@ const uniformGroup = new UniformGroup({
 uniformGroup.uniforms.uTime = 100;
 
 ```
-**new**
+**New**
 ```ts
 const uniformGroup = new UniformGroup({
-  uTime:{value:1, type:'f32',
+  uTime:{value:1, type:'f32'},
 });
 
 uniformGroup.uniforms.uTime = 100; // still accessed the same!
@@ -379,22 +379,22 @@ uniformGroup.uniforms.uTime = 100; // still accessed the same!
 
 The best way to play and fully and get to know this new setup please check out the Mesh and Shader examples:
 
-**old**: [v7 example](https://pixijs.com/7.x/examples/mesh-and-shaders/triangle-color)
-**new**: [v8 example](https://pixijs.com/8.x/examples/mesh-and-shaders/triangle-color)
+**Old**: [v7 example](https://pixijs.com/7.x/examples/mesh-and-shaders/triangle-color)
+**New**: [v8 example](https://pixijs.com/8.x/examples/mesh-and-shaders/triangle-color)
 
 
 ### Filters
 
 Filters work almost exactly the same, unless you are constructing a custom one. If this is the case, the shader changes mentioned above need to taken into account.
 
-**old**
+**Old**
 ```ts
   const filter = new Filter(vertex, fragment, {
       uTime: 0.0,
   });
 ```
 
-**new**
+**New**
 ```ts
     const filter = new Filter({
         glProgram: GlProgram.from({
@@ -408,17 +408,17 @@ Filters work almost exactly the same, unless you are constructing a custom one. 
         },
     });
 ```
-**old**: [v7 example](https://pixijs.com/7.x/examples/filters-advanced/custom)
-**new**: [v8 example](https://pixijs.com/8.x/examples/filters-advanced/custom)
+**Old**: [v7 example](https://pixijs.com/7.x/examples/filters-advanced/custom)
+**New**: [v8 example](https://pixijs.com/8.x/examples/filters-advanced/custom)
 
 If you're using the [community filters](https://github.com/pixijs/filters), note that the `@pixi/filter-*` packages are no-longer maintained for v8, however, you can import directly from the `pixi-filters` package as sub-modules.
 
-***old**
+**Old**
 ```ts
 import { AdjustmentFilter } from '@pixi/filter-adjustment';
 ```
 
-***new**
+**New**
 ```ts
 import { AdjustmentFilter } from 'pixi-filters/adjustment';
 ```
@@ -456,7 +456,7 @@ Another optimization is that `ParticleContainer` does not calculate its own boun
 
 ---
 
-**OLD**
+**Old**
 ```ts
 const container = new ParticleContainer();
 
@@ -466,7 +466,7 @@ for (let i = 0; i < 100000; i++) {
 }
 ```
 
-**NEW**
+**New**
 ```ts
 const container = new ParticleContainer();
 
@@ -522,36 +522,35 @@ const container = new ParticleContainer({
   - The BaseTexture `mipmap` property has been renamed to `autoGenerateMipmaps`.
   - Mipmaps for `RenderTextures` have been adjusted so that developer is responsible for updating them mipmaps. Mipmap generation can be expensive, and due to the new reactive way we handle textures we do not want to accidentally generate mipmaps when they are not required.
 
-```ts
-const myRenderTexture = RenderTexture.create({width:100, height:100, autoGenerateMipmaps:true});
+  ```ts
+  const myRenderTexture = RenderTexture.create({width:100, height:100, autoGenerateMipmaps:true});
 
-// do some rendering..
-renderer.render({target:myRenderTexture, container:scene});
+  // do some rendering..
+  renderer.render({target:myRenderTexture, container:scene});
 
-// now refresh mipmaps when you are ready
-myRenderTexture.source.updateMipmaps();
-```
-
+  // now refresh mipmaps when you are ready
+  myRenderTexture.source.updateMipmaps();
+  ```
 
 - Due to the new way PixiJS handles things internally, sprites no longer get notified if a texture's UVs have been modified. The best practice is not to modify texture UVs once they have been created. It's best to have textures ready to go (they are inexpensive to create and store).
 - Sometimes, you might want to employ a special technique that animates the UVs. In this last instance, you will be responsible for updating the sprite (it's worth noting that it may update automatically - but due to the new optimizations, this will not be guaranteed). Updating the source data (e.g., a video texture) will, however, always be reflected immediately.
 
-```ts
-const texture = await Assets.load('bunny.png');
-const sprite = new Sprite(texture);
+  ```ts
+  const texture = await Assets.load('bunny.png');
+  const sprite = new Sprite(texture);
 
-texture.frame.width = texture.frame.width/2;
-texture.update();
+  texture.frame.width = texture.frame.width/2;
+  texture.update();
 
-// guarantees the texture changes will be reflected on the sprite
-sprite.onViewUpdate();
+  // guarantees the texture changes will be reflected on the sprite
+  sprite.onViewUpdate();
 
 
-// alternatively you can hooke into the sprites event
-texture.on('update', ()=>{sprite.onViewUpdate});
-```
+  // alternatively you can hooke into the sprites event
+  texture.on('update', ()=>{sprite.onViewUpdate});
+  ```
 
-The act of adding and removing the event when a sprite's texture was changed led to an unacceptable performance drop, especially when swapping many textures (imagine shooting games with lots of keyframe textures swapping). This is why we now leave that responsibility to the user.
+  The act of adding and removing the event when a sprite's texture was changed led to an unacceptable performance drop, especially when swapping many textures (imagine shooting games with lots of keyframe textures swapping). This is why we now leave that responsibility to the user.
 
 - New Container culling approach
 


### PR DESCRIPTION
While going through the v8 migration guide there were typos and formatting issues throughout as well as inconsistencies with formatting. This PR attempts to fix all these issues