### PR TITLE
fix(guides): formatting inconsistencies in SVG rendering guide

### DIFF
--- a/docs/guides/components/assets/svg.mdx
+++ b/docs/guides/components/assets/svg.mdx
@@ -21,13 +21,10 @@ PixiJS provides powerful support for rendering SVGs, allowing developers to inte
 
 SVGs have several advantages over raster images like PNGs:
 
-✅ **Smaller File Sizes** – SVGs can be significantly smaller than PNGs, especially for large but simple shapes. A high-resolution PNG may be several megabytes, while an equivalent SVG could be just a few kilobytes.
-
-✅ **Scalability** – SVGs scale without losing quality, making them perfect for responsive applications and UI elements.
-
-✅ **Editable After Rendering** – Unlike textures, SVGs rendered via Graphics can be modified dynamically (e.g., changing stroke colors, modifying shapes).
-
-✅ **Efficient for Simple Graphics** – If the graphic consists of basic shapes and paths, SVGs can be rendered efficiently as vector graphics.
+- ✅ **Smaller File Sizes** – SVGs can be significantly smaller than PNGs, especially for large but simple shapes. A high-resolution PNG may be several megabytes, while an equivalent SVG could be just a few kilobytes.
+- ✅ **Scalability** – SVGs scale without losing quality, making them perfect for responsive applications and UI elements.
+- ✅ **Editable After Rendering** – Unlike textures, SVGs rendered via Graphics can be modified dynamically (e.g., changing stroke colors, modifying shapes).
+- ✅ **Efficient for Simple Graphics** – If the graphic consists of basic shapes and paths, SVGs can be rendered efficiently as vector graphics.
 
 However, SVGs can also be computationally expensive to parse, particularly for intricate illustrations with many paths or effects.
 
@@ -83,13 +80,13 @@ This ensures the texture appears at the correct size and resolution.
 
 ### Pros & Cons
 
-✅ **Fast to render** (rendered as a quad, not geometry)
-✅ **Good for static images**
-✅ **Supports resolution scaling for precise sizing**
-✅ **Ideal for complex SVGs that do not need crisp vector scaling** (e.g., UI components with fixed dimensions)
-❌ **Does not scale cleanly** (scaling may result in pixelation)
-❌ **Less flexibility** (cannot modify the shape dynamically)
-❌ **Texture Size Limit** A texture can only be up to 4096x4096 pixels, so if you need to render a larger SVG, you will need to use the Graphics method.
+- ✅ **Fast to render** (rendered as a quad, not geometry)
+- ✅ **Good for static images**
+- ✅ **Supports resolution scaling for precise sizing**
+- ✅ **Ideal for complex SVGs that do not need crisp vector scaling** (e.g., UI components with fixed dimensions)
+- ❌ **Does not scale cleanly** (scaling may result in pixelation)
+- ❌ **Less flexibility** (cannot modify the shape dynamically)
+- ❌ **Texture Size Limit** A texture can only be up to 4096x4096 pixels, so if you need to render a larger SVG, you will need to use the Graphics method.
 
 ### Best Use Cases
 
@@ -144,12 +141,12 @@ Since it's loaded via `Assets.load`, it will be cached and reused, much like a t
 
 ### Pros & Cons
 
-✅ **Retains vector scalability** (no pixelation when zooming)
-✅ **Modifiable after rendering** (change colors, strokes, etc.)
-✅ **Efficient for simple graphics**
-✅ **fast rendering if SVG structure does not change** (no need to reparse)
-❌ **More expensive to parse** (complex SVGs can be slow to render)
-❌ **Not ideal for static images**
+- ✅ **Retains vector scalability** (no pixelation when zooming)
+- ✅ **Modifiable after rendering** (change colors, strokes, etc.)
+- ✅ **Efficient for simple graphics**
+- ✅ **fast rendering if SVG structure does not change** (no need to reparse)
+- ❌ **More expensive to parse** (complex SVGs can be slow to render)
+- ❌ **Not ideal for static images**
 
 ### Best Use Cases
 
@@ -188,16 +185,16 @@ PixiJS supports most SVG features that can be rendered in a Canvas 2D context. B
 
 ### Best Practices
 
-✅ **Use Graphics for scalable and dynamic SVGs**
-✅ **Use Textures for performance-sensitive applications**
-✅ **Use `GraphicsContext` to avoid redundant parsing**
-✅ **Consider `resolution` when using textures to balance quality and memory**
+- ✅ **Use Graphics for scalable and dynamic SVGs**
+- ✅ **Use Textures for performance-sensitive applications**
+- ✅ **Use `GraphicsContext` to avoid redundant parsing**
+- ✅ **Consider `resolution` when using textures to balance quality and memory**
 
 ### Gotchas
 
-⚠ **Large SVGs can be slow to parse** – Optimize SVGs before using them in PixiJS.
-⚠ **Texture-based SVGs do not scale cleanly** – Use higher resolution if necessary.
-⚠ **Not all SVG features are supported** – Complex filters and text elements may not work as expected.
+- ⚠ **Large SVGs can be slow to parse** – Optimize SVGs before using them in PixiJS.
+- ⚠ **Texture-based SVGs do not scale cleanly** – Use higher resolution if necessary.
+- ⚠ **Not all SVG features are supported** – Complex filters and text elements may not work as expected.
 
 ---
 


### PR DESCRIPTION
## Fix Unicode list bullet rendering in documentation

Fixes #187

Unicode bullet points (✅/❌) in Markdown files were not rendering as proper list items, causing content to appear as a single continuous line instead of formatted lists.

### Changes:
- Added `-` prefix to Unicode bullet lines in `docs/guides/components/assets/svg.mdx` to render as proper Markdown lists