### PR TITLE
fix: modify comment about textureGCMaxIdle

### DIFF
--- a/docs/guides/concepts/garbage-collection.md
+++ b/docs/guides/concepts/garbage-collection.md
@@ -65,7 +65,7 @@ const app = new Application();
 
 await app.init({
   textureGCActive: true, // Enable texture garbage collection
-  textureGCMaxIdle: 7200, // 2 hours idle time
+  textureGCMaxIdle: 7200, // 2 minutes idle time
   textureGCCheckCountMax: 1200, // Check every 20 seconds at 60 FPS
 });
 ```


### PR DESCRIPTION
It seems conflict this description:
"Removes textures unused for 3600 frames (approximately 1 minute at 60 FPS)."

I think its 2 minutes, so I modified.